### PR TITLE
Display area and vehicle HUDs elements

### DIFF
--- a/resources/[race]/race/util_client.lua
+++ b/resources/[race]/race/util_client.lua
@@ -36,7 +36,7 @@ server = createServerCallInterface()
 -- GUI
 
 function showHUD(show)
-	for i,name in ipairs({ 'ammo', 'area_name', 'armour', 'breath', 'clock', 'health', 'money', 'vehicle_name', 'weapon' }) do
+	for i,name in ipairs({ 'ammo', 'armour', 'breath', 'clock', 'health', 'money', 'weapon' }) do
 		setPlayerHudComponentVisible(name, show)
 	end
 end


### PR DESCRIPTION
This change removes `area_name` and `vehicle_name` from HUD blacklist. In my opinion it was a great feature.

Needs testing.

Possible conflicts:
- Maps with custom vehicle models. Name doesn't correspond with model.
- Other HUD elements might be in the way.
- In air or water-only maps the area name "San Andreas" might be shown more than we'd want.