### PR TITLE
Update prices for Cena

### DIFF
--- a/resources/[gameplay]/gcshop/horns/horns_c.lua
+++ b/resources/[gameplay]/gcshop/horns/horns_c.lua
@@ -446,7 +446,7 @@ function onShopInit ( tabPanel )
 	
 	
 	--// Buttons //--
-	local buy = guiCreateButton(0.05, 0.83, 0.22, 0.12, "Buy selected horn\nPrice: 1500 GC (each)", true, buyHornsTab)
+	local buy = guiCreateButton(0.05, 0.83, 0.22, 0.12, "Buy selected horn\nPrice: 2000 GC (each)", true, buyHornsTab)
 	local unbindall = guiCreateButton(0.53, 0.83, 0.14, 0.12, "Unbind\nall horns", true, buyHornsTab)
 	local bindForGamepads = guiCreateButton(0.69, 0.83, 0.26, 0.12, "Bind to a horn control name\n(Esc -> Settings -> Binds)", true, buyHornsTab)
 	unlimited = guiCreateButton(0.77, 0.05, 0.20, 0.15, "Buy unlimited usage\nPrice: 5000 GC", true, perkTab)	

--- a/resources/[gameplay]/gcshop/horns/horns_s.lua
+++ b/resources/[gameplay]/gcshop/horns/horns_s.lua
@@ -1,4 +1,4 @@
-local price = 1500
+local price = 2000
 local unlimitedUses = 5000
 local canHornBeUsed = {}
 local howManyTimes = {}

--- a/resources/[gameplay]/gcshop/maps/maps_client.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_client.lua
@@ -1,5 +1,5 @@
 ﻿PRICE = 1000
-lastWinnerPrice = 350
+lastWinnerPrice = 750
 
 local main_window
 local tab_panel

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -6,7 +6,7 @@ mp_cooldownTime = 360*60 -- Minutes of cooldown
 ----------------------
 
 lastWinner = nil
-lastWinnerPrice = 350
+lastWinnerPrice = 750
 
 -- Race, NTS, RTF
 function finish( rank )

--- a/resources/[gameplay]/gcshop/skin/skins_client.lua
+++ b/resources/[gameplay]/gcshop/skin/skins_client.lua
@@ -101,7 +101,7 @@ function onShopInit ( tabPanel )
 			guiGridListSetItemText(skinGrid, row, colId, skinID, false, false)
 		end
 	end	
-	guiCreateLabel(0.4274,0.0505,0.45,0.05,"Skin price: 3000 GCs",true,skinTab)
+	guiCreateLabel(0.4274,0.0505,0.45,0.05,"Skin price: 1500 GCs",true,skinTab)
 	guiCreateLabel(0.4274,0.1009,0.45,0.05,"You can own multiple skins, but only use one.",true, skinTab)
 	exactSkins = guiCreateLabel(0.4274,0.1537,0.55,0.05,"Your ID purchases so far: none",true,skinTab)
 	exactSkins2 = guiCreateLabel(0.4274,0.2037,0.55,0.05,"",true,skinTab)

--- a/resources/[gameplay]/gcshop/skin/skins_server.lua
+++ b/resources/[gameplay]/gcshop/skin/skins_server.lua
@@ -1,5 +1,5 @@
 gcSkins = {}
-local price = 3000
+local price = 1500
 
 function handleBuying(player, id)
 	-- exports.gc:addPlayerGreencoins(player, (-1*price))

--- a/resources/[gameplay]/gcshop/teams/teams_s.lua
+++ b/resources/[gameplay]/gcshop/teams/teams_s.lua
@@ -5,7 +5,7 @@ local playerteams = {}
 local playertimestamp = {}
 local invites = {}
 local duration = 1
-local team_duration = 30 * 24 * 60 * 60
+local team_duration = 20 * 24 * 60 * 60
 
 local team_sql = [[CREATE TABLE IF NOT EXISTS `team` (
 	`teamid` smallint(5) unsigned NOT NULL AUTO_INCREMENT, 


### PR DESCRIPTION
] Cena: Hey guys. I wanted to suggest some price changes ingame. Basically for Renewing clans, Horns and maps. 

- The current price to renew a team is 2500 GCs for 30 days for a maximum of 60 days.  I think changing it to 2500 GCs for 20 days for a maximum of 60 days would be much better. So the players would need to renew their clan 3 times instead of 2.

- Horns are being bought a lot lately specially that we keep adding more horns. The current price is 1500 GCs per horn. While skin is 3000 GCs and honestly no one bother to buy those skins + they are being very expensive. I think we can make more use of the horns and skin by changing the horns price from 1500 GCs to 2000 GCs and changing the price for a skin from 3000 GCs to 1500 GCs. That way we can at least think players would spend their GCs on some skins as well.

- Buying maps are being bought A LOT specially with SH maps. There are a lot of old players and they can win easily since they have a lot of experience ingame compared to new players, so 350 GCs isn't really much in my opinion. The current price for buying a map (if you win the previous map) is 350 GCs while the price for a map (if you didn't win the previous map) is 1000 GCs which is obviously a huge difference. My suggestion for mapping price is 750 GCs IF you won the previous map instead of 350 GCs. 1000 GCs IF you didn't win the previous map (same as it is now). 

Lemme know what you think!