### PR TITLE
[gus] Tray notification on map started.

### DIFF
--- a/resources/[gameplay]/gus/gus_c.lua
+++ b/resources/[gameplay]/gus/gus_c.lua
@@ -247,3 +247,11 @@ addEventHandler("onClientMapLaunched", root, function()
 		setSoundPaused( u, false )
 	end
 end)
+
+-- tray notification on map started
+
+addEventHandler("onClientResourceStart", getRootElement(),
+    function(res)
+        createTrayNotification("[MrGreenGaming] Map (" .. getResourceName(res) .. ") just started.", "default" )
+    end
+)


### PR DESCRIPTION
- a notification will be send to desktop when a map gets started.