### PR TITLE
spawnpoint change message will be no longer spammed in the chatbox.

### DIFF
--- a/resources/[gameplay]/gcshop/items/items_s.lua
+++ b/resources/[gameplay]/gcshop/items/items_s.lua
@@ -473,7 +473,7 @@ function callSpawn ( player )
 		elementID, distance, index = changeSpawn(player)
 	end
 	if elementID then
-		return outputChatBox("[GC] Changed to spawnpoint "..index..". Distance: "..distance.."m", player, 0,255,0) -- less info
+		return outputConsole("Changed to spawnpoint "..index..". Distance: "..distance.."m", player) -- less info
 		-- return outputChatBox('[GC] Changed to spawnpoint \"' .. tostring(elementID) .. '\" .. ('..index..'/'..distance..'m)', player, 0,255,0)
 	end
 end


### PR DESCRIPTION
- moved spawnpoint change notification from chatbox to "F8" console.