### PR TITLE
CoreMarkers delay adjustment

### DIFF
--- a/resources/[maps]/coremarkers/client.lua
+++ b/resources/[maps]/coremarkers/client.lua
@@ -1,6 +1,6 @@
 math.randomseed(getTickCount())
 
-local delay = 500
+local delay = 2000
 local animSpeed = 20
 local speedItemTime = 12000
 


### PR DESCRIPTION
2s delay after you pick up marker before you can use it (instead of 0.5s, too quick as we tested)