### PR TITLE
CoreMarkers v0.9.1.1 HotFix

### DIFF
--- a/resources/[maps]/coremarkers/client.lua
+++ b/resources/[maps]/coremarkers/client.lua
@@ -27,20 +27,20 @@ addEventHandler("getAllowedPowerTypes", root, getAllowedPowerTypes)
 
 
 addEventHandler("onClientResourceStart", resourceRoot, 
-function()	
-	setElementData(localPlayer, "coremarkers_powerType", false, true)
-	setElementData(localPlayer, "coremarkers_isPlayerSlowedDown", false, true)
-	setElementData(localPlayer, "coremarkers_isPlayerRektBySpikes", false, true)
-	
-	engineImportTXD ( engineLoadTXD ( "oil.txd" ) , 2717 ) 
-	engineImportTXD ( engineLoadTXD ( "crate.txd" ) , 3798 ) 
-	
-	engineSetModelLODDistance(1225, 100)
-	engineSetModelLODDistance(3374, 300)
-	engineSetModelLODDistance(2717, 300)
-	engineSetModelLODDistance(3798, 300)
-	engineSetModelLODDistance(13645, 300)
-end
+	function()	
+		setElementData(localPlayer, "coremarkers_powerType", false, true)
+		setElementData(localPlayer, "coremarkers_isPlayerSlowedDown", false, true)
+		setElementData(localPlayer, "coremarkers_isPlayerRektBySpikes", false, true)
+		
+		engineImportTXD ( engineLoadTXD ( "oil.txd" ) , 2717 ) 
+		engineImportTXD ( engineLoadTXD ( "crate.txd" ) , 3798 ) 
+		
+		engineSetModelLODDistance(1225, 100)
+		engineSetModelLODDistance(3374, 300)
+		engineSetModelLODDistance(2717, 300)
+		engineSetModelLODDistance(3798, 300)
+		engineSetModelLODDistance(13645, 300)
+	end
 )
 
 
@@ -402,7 +402,9 @@ addEvent("startShootMinigun", true)
 addEventHandler("startShootMinigun", root, 
 	function(thePlayer)
 		if not isTimer(minigunTimer[thePlayer]) then
-			removePower(nil, minigunItemTime)
+			if thePlayer == localPlayer then
+				removePower(nil, minigunItemTime)
+			end
 			minigunTimer[thePlayer] = setTimer(
 				function()
 					if minigunPlayer[thePlayer] then

--- a/resources/[maps]/coremarkers/meta.xml
+++ b/resources/[maps]/coremarkers/meta.xml
@@ -38,6 +38,6 @@
     <script src="client.lua" type="client"></script>
     <script src="server.lua" type="server"></script>
 
-<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.1" type="script" />
+<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.1.1" type="script" />
 	<min_mta_version server="1.5.5-9.14060" />
 </meta>

--- a/resources/[maps]/coremarkers/utilites_s.lua
+++ b/resources/[maps]/coremarkers/utilites_s.lua
@@ -1,13 +1,13 @@
-function showText_Create(red, green, blue, text, time, thePlayer)
-showText_Display = textCreateDisplay ()
-showText_Text = textCreateTextItem ( "", 0.5, 0.3, 2, 0, 255, 0, 255, 2.3, "center", "center", 255 )
-textDisplayAddText ( showText_Display, showText_Text )
+function showText_Create ( red, green, blue, text, time, thePlayer )
+	showText_Display = textCreateDisplay ()
+	showText_Text = textCreateTextItem ( "", 0.5, 0.3, 2, 0, 255, 0, 255, 2.3, "center", "center", 255 )
+	textDisplayAddText ( showText_Display, showText_Text )
 end
 
 function showText ( red, green, blue, text, time, thePlayer )
-textItemSetColor ( showText_Text, red, green, blue, 255 )
-textItemSetText ( showText_Text, text )
-outputChatBox(RGBToHex(red, green, blue)..text, thePlayer, red, green, blue, true)
+	textItemSetColor ( showText_Text, red, green, blue, 255 )
+	textItemSetText ( showText_Text, text )
+	outputChatBox(RGBToHex(red, green, blue)..text, thePlayer, red, green, blue, true)
 	
 	if ( showText_timer	) then
 		killTimer ( showText_timer )
@@ -26,8 +26,8 @@ outputChatBox(RGBToHex(red, green, blue)..text, thePlayer, red, green, blue, tru
 end
 
 function showText_Remove()
-showText_timer = nil
-local players = getElementsByType( "player" )
+	showText_timer = nil
+	local players = getElementsByType( "player" )
 	
 	for k,v in ipairs(players) do
 		textDisplayRemoveObserver( showText_Display, v )
@@ -35,13 +35,13 @@ local players = getElementsByType( "player" )
 end
 
 function RGBToHex(red, green, blue, alpha)
-if((red < 0 or red > 255 or green < 0 or green > 255 or blue < 0 or blue > 255) or (alpha and (alpha < 0 or alpha > 255))) then
-	return nil
-end
-if(alpha) then
-	return string.format("#%.2X%.2X%.2X%.2X", red,green,blue,alpha)
-else
-		return string.format("#%.2X%.2X%.2X", red,green,blue)
-end
+	if((red < 0 or red > 255 or green < 0 or green > 255 or blue < 0 or blue > 255) or (alpha and (alpha < 0 or alpha > 255))) then
+		return nil
+	end
+	if(alpha) then
+		return string.format("#%.2X%.2X%.2X%.2X", red,green,blue,alpha)
+	else
+			return string.format("#%.2X%.2X%.2X", red,green,blue)
+	end
 end
 


### PR DESCRIPTION
- HotFix: Fixed bug appeared in v0.9.1: when player used Minigun it triggered removePower() timer for all players, should be only for a Minigun owner.
- Minor: Fixed function to delete ramps after contact with player (it was working wrong)
- A bit of code styling (comments, spaces, etc to read and understand code easier for myself first of all)