### PR TITLE
CoreMarkers HotFix

### DIFF
--- a/resources/[maps]/coremarkers/meta.xml
+++ b/resources/[maps]/coremarkers/meta.xml
@@ -38,6 +38,6 @@
     <script src="client.lua" type="client"></script>
     <script src="server.lua" type="server"></script>
 
-<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.1.1" type="script" />
+<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.1.2" type="script" />
 	<min_mta_version server="1.5.5-9.14060" />
 </meta>

--- a/resources/[maps]/coremarkers/server.lua
+++ b/resources/[maps]/coremarkers/server.lua
@@ -733,3 +733,16 @@ function removeMinigun()
 end
 addEvent("removeMinigun", true)
 addEventHandler("removeMinigun", root, removeMinigun)
+
+
+--------------------------------------------
+-- Force CoreMarkers to stop on map stops --
+--------------------------------------------
+addEvent('onGamemodeMapStop', true)
+addEventHandler('onGamemodeMapStop', root, 
+	function()
+		if getResourceState(resource) == "running" then
+			stopResource(resource)
+		end
+    end
+)


### PR DESCRIPTION
Possible fix for solid boxes. Forces coremarkers to stop when map stops (as it should be)