### PR TITLE
CoreMarkers Mini Update

### DIFF
--- a/resources/[maps]/coremarkers/meta.xml
+++ b/resources/[maps]/coremarkers/meta.xml
@@ -1,6 +1,6 @@
 <meta>
 	<file src="marker.mp3"></file>
-	<file src="kmz.mp3"></file>
+	<!--Disabled <file src="kmz.mp3"></file> -->
 	<file src="speed.mp3"></file>
 	<file src="fly.mp3"></file>
     <file src="oil.txd"></file>
@@ -27,7 +27,7 @@
 	<file src="pics/nitro.png"></file>
 	<file src="pics/speed.png"></file>
 	<file src="pics/fly.png"></file>
-	<file src="pics/kmz.png"></file>
+	<!--Disabled <file src="pics/kmz.png"></file> -->
 	<file src="pics/minigun.png"></file>
 	
 	<script src="utilites_s.lua" type="server"></script>
@@ -38,6 +38,6 @@
     <script src="client.lua" type="client"></script>
     <script src="server.lua" type="server"></script>
 
-<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.1.3" type="script" />
+	<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.1.4" type="script" />
 	<min_mta_version server="1.5.5-9.14060" />
 </meta>

--- a/resources/[maps]/coremarkers/server.lua
+++ b/resources/[maps]/coremarkers/server.lua
@@ -15,7 +15,7 @@ addEventHandler('onMapStarting', resourceRoot,
 			powerTypes = {
 					{"repair"},
 					{"spikes"},
-					{"boost"},
+					--{"boost"},
 					{"oil"},
 					{"hay"},
 					{"barrels"},
@@ -26,12 +26,12 @@ addEventHandler('onMapStarting', resourceRoot,
 					{"rock"},
 					--{"smoke"},
 					{"nitro"},
-					{"speed"},
+					--{"speed"},
 					--{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
-		elseif currentGameMode == "FREEROAM" then
+		elseif currentGameMode == "FREEROAM" then --race
 			powerTypes = {
 					{"repair"},
 					{"spikes"},
@@ -48,10 +48,10 @@ addEventHandler('onMapStarting', resourceRoot,
 					{"nitro"},
 					{"speed"},
 					{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
-		elseif currentGameMode == "SPRINT" then
+		elseif currentGameMode == "SPRINT" then --also race
 			powerTypes = {
 					{"repair"},
 					{"spikes"},
@@ -68,7 +68,7 @@ addEventHandler('onMapStarting', resourceRoot,
 					{"nitro"},
 					{"speed"},
 					{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
 		elseif currentGameMode == "CAPTURE THE FLAG" then
@@ -88,7 +88,7 @@ addEventHandler('onMapStarting', resourceRoot,
 					{"nitro"},
 					{"speed"},
 					{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
 		elseif currentGameMode == "REACH THE FLAG" then
@@ -108,12 +108,12 @@ addEventHandler('onMapStarting', resourceRoot,
 					{"nitro"},
 					{"speed"},
 					{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
 		elseif currentGameMode == "NEVER THE SAME" then
 			powerTypes = {
-					{"repair"},
+					--{"repair"},
 					{"spikes"},
 					{"boost"},
 					{"oil"},
@@ -128,7 +128,7 @@ addEventHandler('onMapStarting', resourceRoot,
 					--{"nitro"},
 					{"speed"},
 					{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
 		elseif currentGameMode == "SHOOTER" then
@@ -148,7 +148,7 @@ addEventHandler('onMapStarting', resourceRoot,
 					{"nitro"},
 					{"speed"},
 					{"fly"},
-					{"kmz"},
+					--{"kmz"},
 					{"minigun"},
 			}
 		end


### PR DESCRIPTION
- Fully disabled Kamikaze item because everyone hate it
- NTS only: removed repair item
- DD only: removed boost and speed items