### PR TITLE
CoreMarkers HotFix v0.9.4 + Map Editor Tools Fixes for Map Tests + CoreMarkers: Custom Items List

### DIFF
--- a/editorplugin/mrgreen/mrgreen/edf_s.lua
+++ b/editorplugin/mrgreen/mrgreen/edf_s.lua
@@ -22,32 +22,37 @@ addEventHandler( "onResourceStart", root, function ( res )
 		racemode(source)
 	end
 
-	-- while testing in map editor this triggers twice for each randommarker, fuck it i dont know why
 	for _, mrkr in ipairs( getElementsByType'randommarker', getResourceRootElement(res) ) do
-		local x, y, z = getElementPosition(mrkr)
-		elements[#elements+1] = createMarker (x, y, z, "cylinder", markersize, 0, 255, 0, 150) -- Creates the markers
-		setElementParent(elements[#elements], mrkr)
-		addEventHandler('onMarkerHit', elements[#elements], function(hitElement, dim)
-			if not (dim and getElementType(hitElement) == 'vehicle' and not isVehicleBlown(hitElement) and getVehicleController(hitElement) and getElementHealth(getVehicleController(hitElement)) ~= 0) then return end
-			outputChatBox('Markers: You picked up a RandomMarkers pickup', getVehicleController(hitElement), 0, 255, 0)
-		end)
+		if getElementType(getElementParent(mrkr)) == "map" then --ignore elements with parent mapContainer (they are created by map editor), only elements from the .map will be used
+			local x, y, z = getElementPosition(mrkr)
+			elements[#elements+1] = createMarker (x, y, z, "cylinder", markersize, 0, 255, 0, 150) -- Creates the markers
+			setElementParent(elements[#elements], mrkr)
+			addEventHandler('onMarkerHit', elements[#elements], function(hitElement, dim)
+				if not (dim and getElementType(hitElement) == 'vehicle' and not isVehicleBlown(hitElement) and getVehicleController(hitElement) and getElementHealth(getVehicleController(hitElement)) ~= 0) then return end
+				outputChatBox('Markers: You picked up a RandomMarkers pickup', getVehicleController(hitElement), 0, 255, 0)
+			end)
+		end
 	end
-	
+
+	local coremarkersRes = getResourceFromName("coremarkers")
+	if coremarkersRes and getResourceState( coremarkersRes ) == "running" then return end
 	for _, mrkr in ipairs( getElementsByType'coremarker', getResourceRootElement(res) ) do
-		local x, y, z = getElementPosition(mrkr)
-		local col = createColSphere(x, y, z, 3.7)
-		elements[#elements+1] = col
-		local object = createObject(3798, x, y, z+0.3)
-		local marker = createMarker (x, y, z-2.75, "cylinder", 3.3, 0, 255, 0, 150)
-		setElementParent(object, col)
-		setElementParent(marker, col)
-		setObjectScale(object, 0.6)
-		setElementCollisionsEnabled(object, false)
-		addEventHandler("onColShapeHit", col, function(thePlayer)
-			if getElementType(thePlayer) == "player" then
-				outputChatBox('Markers: You picked up a CoreMarkers pickup', thePlayer, 0, 255, 0)
-			end
-		end)
+		if getElementType(getElementParent(mrkr)) == "map" then 
+			local x, y, z = getElementPosition(mrkr)
+			local col = createColSphere(x, y, z, 3.7)
+			elements[#elements+1] = col
+			local object = createObject(3798, x, y, z+0.3)
+			local marker = createMarker (x, y, z-2.75, "cylinder", 3.3, 0, 255, 0, 150)
+			setElementParent(object, col)
+			setElementParent(marker, col)
+			setObjectScale(object, 0.6)
+			setElementCollisionsEnabled(object, false)
+			addEventHandler("onColShapeHit", col, function(thePlayer)
+				if getElementType(thePlayer) == "player" then
+					outputChatBox('Markers: You picked up a CoreMarkers pickup', thePlayer, 0, 255, 0)
+				end
+			end)
+		end
 	end
 end)
 

--- a/editorplugin/mrgreen/mrgreen/meta.xml
+++ b/editorplugin/mrgreen/mrgreen/meta.xml
@@ -1,5 +1,5 @@
 <meta>
-	<info author="SDK" description="Map editor plugin for MrGreenGaming race modes" type="script" version="0.2.1" edf:definition="mrgreen.edf" />
+	<info author="SDK" description="Map editor plugin for MrGreenGaming race modes" type="script" version="0.2.2" edf:definition="mrgreen.edf" />
 	
 	<script src="edf_s.lua" type="server" />
 	<script src="edf_c.lua" type="client" />

--- a/editorplugin/mrgreen/mrgreen/mrgreen.edf
+++ b/editorplugin/mrgreen/mrgreen/mrgreen.edf
@@ -25,6 +25,13 @@
 				description="Respawn delay in miliseconds. 1s = 1000ms" 
 				required="true"
 	/>
+	<setting 	name="coremarkers_items" 
+				friendlyname="CoreMarkers Items"
+				type="string" 				
+				default=""
+				description="List of CoreMarkers items separated by comma. Leave empty if you want it to be default. Example: repair,spikes,boost,oil,hay,barrels,ramp,rocket,magnet,jump,rock,smoke,nitro,speed,fly,kmz,minigun" 
+				required="true"
+	/>
 	
  	<!-- <element name="checkpoint" friendlyname="NTS Checkpoint">
 		<data name="nts" type="selection:vehicle,water,air" required="true" />

--- a/editorplugin/mrgreen/mrgreen/nfsarrows/edf_s.lua
+++ b/editorplugin/mrgreen/mrgreen/nfsarrows/edf_s.lua
@@ -4,6 +4,8 @@ local color = nil
 addEventHandler("onResourceStart", root, 
 	function(res)
 		if getResourceName(res) ~= "editor_test" then return end
+		local nfsarrowsRes = getResourceFromName("nfsarrows")
+		if nfsarrowsRes and getResourceState( nfsarrowsRes ) == "running" then return end
 		--------------------------------------------------------------------------------------------------------
 		for _, v in pairs( getElementsByType("nfs_arrow", getResourceRootElement(res)) ) do
 			local x, y, z = getElementData(v, "posX"), getElementData(v, "posY"), getElementData(v, "posZ")+0.05

--- a/resources/[maps]/coremarkers/client.lua
+++ b/resources/[maps]/coremarkers/client.lua
@@ -53,7 +53,7 @@ function getRandomPower()
 		powerTypes = table.copy(powerTypesBackup)
 	end
 	local randomNumber = math.random(#powerTypes)
-	randomPower = unpack(powerTypes[randomNumber])
+	randomPower = powerTypes[randomNumber]
 	table.remove(powerTypes, randomNumber)
 	--Make kmz appear less often
 	if randomPower == "kmz" then
@@ -67,14 +67,14 @@ function getRandomPower()
 			if #powerTypes == 0 then
 				powerTypes = table.copy(powerTypesBackup)
 				for i=1, #powerTypes do
-					if unpack(powerTypes[i]) == "kmz" then
+					if powerTypes[i] == "kmz" then
 						table.remove(powerTypes, i)
 						--outputChatBox('removed kmz from new table')
 					end
 				end
 			end
 			local randomNumber = math.random(#powerTypes)
-			randomPower = unpack(powerTypes[randomNumber])
+			randomPower = powerTypes[randomNumber]
 			table.remove(powerTypes, randomNumber)
 		end
 	end
@@ -105,7 +105,7 @@ function changePic(number)
 	if not isTimer(stopRoulette) then return end
 	
 	local timeleft = getTimerDetails(stopRoulette) 
-	guiStaticImageLoadImage(_typePicture, "pics/"..unpack(powerTypesBackup[number])..".png")
+	guiStaticImageLoadImage(_typePicture, "pics/"..powerTypesBackup[number]..".png")
 	
 	if number >= 1 and number < #powerTypesBackup then
 		nextNumber = number+1

--- a/resources/[maps]/coremarkers/client.lua
+++ b/resources/[maps]/coremarkers/client.lua
@@ -24,7 +24,7 @@ function getAllowedPowerTypes(tbl)
 	powerTypesBackup = table.copy(powerTypes)
 end
 addEvent("getAllowedPowerTypes", true)
-addEventHandler("getAllowedPowerTypes", root, getAllowedPowerTypes)
+addEventHandler("getAllowedPowerTypes", resourceRoot, getAllowedPowerTypes)
 
 
 addEventHandler("onClientResourceStart", resourceRoot, 
@@ -98,7 +98,7 @@ function getRandomPower()
 	, delay, 1, randomPower)
 end
 addEvent("getRandomPower", true)
-addEventHandler("getRandomPower", root, getRandomPower)
+addEventHandler("getRandomPower", resourceRoot, getRandomPower)
 
 function changePic(number)
 	if not isElement(_typePicture) then return end
@@ -164,7 +164,7 @@ function removePower(powerType, delay)
 	, delay or 0, 1)
 end
 addEvent('removePower', true)
-addEventHandler('removePower', root, removePower)
+addEventHandler('removePower', resourceRoot, removePower)
 addEvent('onClientPlayerFinish', true)
 addEventHandler('onClientPlayerFinish', root, removePower)
 
@@ -377,7 +377,7 @@ function DrawLaser(player)
 end
 
 addEvent("slowDownPlayer", true)
-addEventHandler("slowDownPlayer", root, 
+addEventHandler("slowDownPlayer", resourceRoot, 
 	function (magnetSlowDownTime)
 		stopSpeed()
 		if isTimer(slowDownTimer) then
@@ -394,7 +394,7 @@ local minigun = {}
 local minigunPlayer = {}
 local minigunTimer = {}
 addEvent("giveMinigun", true)
-addEventHandler("giveMinigun", root, 
+addEventHandler("giveMinigun", resourceRoot, 
 	function(theVehicle)
 		local minX, minY, minZ, maxX, maxY, maxZ = getElementBoundingBox(theVehicle)
 		local x, y, z = getPositionFromElementOffset(theVehicle, 0, maxY+1, 0)
@@ -422,7 +422,7 @@ addEventHandler("giveMinigun", root,
 )
 
 addEvent("startShootMinigun", true)
-addEventHandler("startShootMinigun", root, 
+addEventHandler("startShootMinigun", resourceRoot, 
 	function(thePlayer)
 		if not isTimer(minigunTimer[thePlayer]) then
 			if thePlayer == localPlayer then
@@ -451,7 +451,7 @@ addEventHandler("startShootMinigun", root,
 )
 
 addEvent("stopShootMinigun", true)
-addEventHandler("stopShootMinigun", root, 
+addEventHandler("stopShootMinigun", resourceRoot, 
 	function(thePlayer)
 		local minigun1 = minigunPlayer[thePlayer][1]
 		local minigun2 = minigunPlayer[thePlayer][2]
@@ -463,7 +463,7 @@ addEventHandler("stopShootMinigun", root,
 )
 
 addEvent('createExplosionEffect', true)
-addEventHandler('createExplosionEffect', root, 
+addEventHandler('createExplosionEffect', resourceRoot, 
 function (x, y, z)
 	createExplosion(x, y, z, 0, true, -1.0, false)
 
@@ -503,7 +503,7 @@ addEventHandler("onClientPreRender", root,
 
 local smoke = {}
 addEvent("createSmokeEffect", true)
-addEventHandler("createSmokeEffect", root,
+addEventHandler("createSmokeEffect", resourceRoot,
 function (x, y, z, rz, theVehicle)
 	local effect0 = createEffect("riot_smoke", x, y, z, 0, 0, rz, 300)
 	local effect1 = createEffect("riot_smoke", x, y, z, 0, 0, rz, 300)
@@ -519,7 +519,7 @@ end
 )
 
 addEvent("spikesTimerFunction", true)
-addEventHandler("spikesTimerFunction", root, 
+addEventHandler("spikesTimerFunction", resourceRoot, 
 function ()
 	if isTimer(spikesTimer) then
 		killTimer(spikesTimer)
@@ -539,7 +539,7 @@ end
 
 
 addEvent("hideSpikesRepairHUD", true)
-addEventHandler("hideSpikesRepairHUD", root, 
+addEventHandler("hideSpikesRepairHUD", resourceRoot, 
 function ()
 	if isTimer(spikesTimer) then
 		killTimer(spikesTimer)
@@ -566,10 +566,10 @@ function stopSpeed()
 	screenColor = nil
 end
 addEvent("stopSpeed", true)
-addEventHandler("stopSpeed", root, stopSpeed)
+addEventHandler("stopSpeed", resourceRoot, stopSpeed)
 
 addEvent("stopFly", true)
-addEventHandler("stopFly", root, 
+addEventHandler("stopFly", resourceRoot, 
 function ()
 	if tRestoreAllSounds then
 		for sound,volume in pairs(tRestoreAllSounds) do
@@ -624,13 +624,13 @@ function create3DSound(theVehicle, sound)
 	return sounds[theVehicle]
 end
 addEvent("create3DSound", true)
-addEventHandler("create3DSound", root, create3DSound)
+addEventHandler("create3DSound", resourceRoot, create3DSound)
 
 function stop3DSound(theVehicle)
 	if isElement(sounds[theVehicle]) then stopSound(sounds[theVehicle]) end
 end
 addEvent("stop3DSound", true)
-addEventHandler("stop3DSound", root, stop3DSound)
+addEventHandler("stop3DSound", resourceRoot, stop3DSound)
 
 local lasthit, lasttick
 
@@ -754,3 +754,10 @@ addEventHandler("onClientRender",  root,
 		end
 	end
 )
+
+function onClientObjectDamage(loss, attacker)
+	if getElementModel(source) == 1225 then
+		triggerServerEvent("destroyBarrel", resourceRoot, source)
+	end
+end
+addEventHandler("onClientObjectDamage", root, onClientObjectDamage)

--- a/resources/[maps]/coremarkers/coremarkers.edf
+++ b/resources/[maps]/coremarkers/coremarkers.edf
@@ -6,7 +6,14 @@
 				description="Respawn delay in miliseconds. 1s = 1000ms" 
 				required="true"
 	/>
-
+	<setting 	name="coremarkers_items" 
+				friendlyname="CoreMarkers Items"
+				type="string" 				
+				default=""
+				description="List of CoreMarkers items separated by comma. Leave empty if you want it to be default. Example: repair,spikes,boost,oil,hay,barrels,ramp,rocket,magnet,jump,rock,smoke,nitro,speed,fly,kmz,minigun" 
+				required="true"
+	/>
+	
 	<element name="coremarker" friendlyname="CoreMarker" icon="pics/icon.png">
 		<data name="position" type="coord3d" default="0,0,0" />
 		<object model="3798" posZ="0.3" editorOnly="true"/>

--- a/resources/[maps]/coremarkers/edf_s.lua
+++ b/resources/[maps]/coremarkers/edf_s.lua
@@ -3,51 +3,55 @@ local elements = {}
 addEventHandler( "onResourceStart", root, function ( res )
 	if getResourceName(res) ~= "editor_test" then return end
 	
+	local coremarkersRes = getResourceFromName("coremarkers")
+	if coremarkersRes and getResourceState( coremarkersRes ) == "running" then return end
 	for _, mrkr in ipairs( getElementsByType'coremarker', getResourceRootElement(res) ) do
-		local x, y, z = getElementPosition(mrkr)
-		local col = createColSphere(x, y, z, 3.7)
-		elements[#elements+1] = col
-		local object = createObject(3798, x, y, z+0.3)
-		local marker = createMarker (x, y, z-2.75, "cylinder", 3.3, 0, 255, 0, 150)
-		setElementParent(object, col)
-		setElementParent(marker, col)
-		setObjectScale(object, 0.6)
-		setElementCollisionsEnabled(object, false)
-		addEventHandler("onColShapeHit", col, function(thePlayer)
-			if getElementType(thePlayer) == "player" then
-				outputChatBox('Markers: You picked up a CoreMarkers pickup', thePlayer, 0, 255, 0)
-			end
-		end)
-		
-		------------------------
-		-- Floating Animation --
-		------------------------
-		local animationSpeed = 1 --the more the slower
-		local box_posZ = 0.3
-		local amplitude = 0.1
-		local easing = "InOutQuad"
-		moveObject(object, animationSpeed*1000, x, y, z+box_posZ+amplitude, 0, 0, 0, easing)
-		setTimer(
-			function()
-				if isElement(object) then 
-					moveObject(object, animationSpeed*1000, x, y, z+box_posZ-amplitude, 0, 0, 0, easing)
+		if getElementType(getElementParent(mrkr)) == "map" then --ignore elements with parent mapContainer (they are created by map editor), only elements from the .map will be used
+			local x, y, z = getElementPosition(mrkr)
+			local col = createColSphere(x, y, z, 3.7)
+			elements[#elements+1] = col
+			local object = createObject(3798, x, y, z+0.3)
+			local marker = createMarker (x, y, z-2.75, "cylinder", 3.3, 0, 255, 0, 150)
+			setElementParent(object, col)
+			setElementParent(marker, col)
+			setObjectScale(object, 0.6)
+			setElementCollisionsEnabled(object, false)
+			addEventHandler("onColShapeHit", col, function(thePlayer)
+				if getElementType(thePlayer) == "player" then
+					outputChatBox('Markers: You picked up a CoreMarkers pickup', thePlayer, 0, 255, 0)
 				end
-			end
-		, animationSpeed*1000, 1)
-		setTimer(
-			function() 
-				if isElement(object) then 
-					moveObject(object, animationSpeed*1000, x, y, z+box_posZ+amplitude, 0, 0, 0, easing) 
-					setTimer(
-						function()
-							if isElement(object) then
-								moveObject(object, animationSpeed*1000, x, y, z+box_posZ-amplitude, 0, 0, 0, easing)
-							end
-					end, animationSpeed*1000, 1)
-				end 
-			end
-		, animationSpeed*2000, 0)
+			end)
+			
+			------------------------
+			-- Floating Animation --
+			------------------------
+			local animationSpeed = 1 --the more the slower
+			local box_posZ = 0.3
+			local amplitude = 0.1
+			local easing = "InOutQuad"
+			moveObject(object, animationSpeed*1000, x, y, z+box_posZ+amplitude, 0, 0, 0, easing)
+			setTimer(
+				function()
+					if isElement(object) then 
+						moveObject(object, animationSpeed*1000, x, y, z+box_posZ-amplitude, 0, 0, 0, easing)
+					end
+				end
+			, animationSpeed*1000, 1)
+			setTimer(
+				function() 
+					if isElement(object) then 
+						moveObject(object, animationSpeed*1000, x, y, z+box_posZ+amplitude, 0, 0, 0, easing) 
+						setTimer(
+							function()
+								if isElement(object) then
+									moveObject(object, animationSpeed*1000, x, y, z+box_posZ-amplitude, 0, 0, 0, easing)
+								end
+						end, animationSpeed*1000, 1)
+					end 
+				end
+			, animationSpeed*2000, 0)
 		end
+	end
 end)
 
 addEventHandler( "onResourceStop", root, function ( res )

--- a/resources/[maps]/coremarkers/meta.xml
+++ b/resources/[maps]/coremarkers/meta.xml
@@ -1,5 +1,5 @@
 <meta>
-	<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.3" type="script" edf:definition="coremarkers.edf" />
+	<info author="AleksCore" name="Core Markers" description="Pickups with random power-ups by AleksCore" version="0.9.4" type="script" edf:definition="coremarkers.edf" />
 	
 	<file src="marker.mp3"></file>
 	<file src="kmz.mp3"></file>

--- a/resources/[maps]/coremarkers/server.lua
+++ b/resources/[maps]/coremarkers/server.lua
@@ -159,7 +159,7 @@ addEventHandler('onMapStarting', resourceRoot,
 )
 
 addEvent("requestAllowedPowerTypes", true)
-addEventHandler("requestAllowedPowerTypes", root, 
+addEventHandler("requestAllowedPowerTypes", resourceRoot, 
 	function()
 		triggerClientEvent(client, "getAllowedPowerTypes", resourceRoot, powerTypes)
 	end
@@ -284,7 +284,7 @@ end
 -- Drop Spikes Event --
 -----------------------
 addEvent("dropSpikes", true)
-addEventHandler("dropSpikes", root, 
+addEventHandler("dropSpikes", resourceRoot, 
 	function (x, y, z, rz)
 		local spikes = createObject(2892, 0, 0, -200, 0, 0, rz+90)
 		setObjectScale(spikes, 0.5)
@@ -312,7 +312,7 @@ addEventHandler("dropSpikes", root,
 )
 
 addEvent("onPlayerPickUpRacePickup", true)
-addEventHandler("onPlayerPickUpRacePickup", root, 
+addEventHandler("onPlayerPickUpRacePickup", resourceRoot, 
 	function(pickupID, pickupType)
 		if pickupType == "repair" then
 			setElementData(source, "coremarkers_isPlayerRektBySpikes", false, true)
@@ -324,7 +324,7 @@ addEventHandler("onPlayerPickUpRacePickup", root,
 --- Drop Hay Event --
 ---------------------
 addEvent("dropHay", true)
-addEventHandler("dropHay", root, 
+addEventHandler("dropHay", resourceRoot, 
 	function (x, y, z, rz)
 		createObject(3374, x, y, z+1.5, 0, 0, rz+90)
 	end
@@ -335,7 +335,7 @@ addEventHandler("dropHay", root,
 --- Drop Rock Event --
 ----------------------
 addEvent("dropRock", true)
-addEventHandler("dropRock", root, 
+addEventHandler("dropRock", resourceRoot, 
 	function (x, y, z, rz)
 		createObject(1305, x, y, z+1.5, 0, 0, rz+90)
 	end
@@ -346,7 +346,7 @@ addEventHandler("dropRock", root,
 --- Smoke Event --
 ------------------
 addEvent("doSmoke", true)
-addEventHandler("doSmoke", root, 
+addEventHandler("doSmoke", resourceRoot, 
 	function (x, y, z, rz)
 		local theVehicle = getPedOccupiedVehicle(client)
 		triggerClientEvent(root, "createSmokeEffect", resourceRoot, x, y, z, rz, theVehicle)
@@ -359,7 +359,7 @@ addEventHandler("doSmoke", root,
 ----------------------
 droppedRampTimer = {}
 addEvent("dropRamp", true)
-addEventHandler("dropRamp", root, 
+addEventHandler("dropRamp", resourceRoot, 
 	function (x, y, z, rz)
 		local ramp = createObject(13645, x, y, z+0.4, 4, 0, rz)
 		local rampCol = createColSphere(x, y, z+0.4, 4)
@@ -385,12 +385,12 @@ addEventHandler("dropRamp", root,
 )
 
 
--------------------------
---- Drop Barrels Event --
--------------------------
+--------------------------
+--- Drop Barrels Events --
+--------------------------
 barrelCreator = {}
 addEvent("dropBarrels", true)
-addEventHandler("dropBarrels", root, 
+addEventHandler("dropBarrels", resourceRoot, 
 	function (x, y, z, rz)
 		local barrels = {}
 		barrels[1] = createObject(1225, x, y, z+0.4)
@@ -405,13 +405,22 @@ addEventHandler("dropBarrels", root,
 	end
 )
 
+addEvent("destroyBarrel", true)
+addEventHandler("destroyBarrel", resourceRoot, 
+	function(barrel)
+		if barrelCreator and barrelCreator[barrel] and isElement(barrelCreator[barrel]) then
+			destroyElement(barrel)
+		end
+	end
+)
+
 
 ----------------------------
 -- Rocket Launcher Events --
 ----------------------------
 local rocketLauncher = {}
 addEvent("createRocketLauncher", true)
-addEventHandler("createRocketLauncher", root, 
+addEventHandler("createRocketLauncher", resourceRoot, 
 	function(maxY)
 		local theVehicle = getPedOccupiedVehicle(client)
 		rocketLauncher[client] = createObject(360, 0, 0, -50)
@@ -420,7 +429,7 @@ addEventHandler("createRocketLauncher", root,
 )
 
 addEvent("removeRocketLauncher", true)
-addEventHandler("removeRocketLauncher", root, 
+addEventHandler("removeRocketLauncher", resourceRoot, 
 	function()
 		if rocketLauncher and isElement(rocketLauncher[client]) then destroyElement(rocketLauncher[client]) end
 	end
@@ -435,14 +444,14 @@ function vehicleChange(oldModel, newModel)
 		end
 	end
 end
-addEventHandler("onElementModelChange", root, vehicleChange)
+addEventHandler("onElementModelChange", resourceRoot, vehicleChange)
 
 
 ---------------------
 --- Drop Oil Event --
 ---------------------
 addEvent("dropOil", true)
-addEventHandler("dropOil", root, 
+addEventHandler("dropOil", resourceRoot, 
 	function (x, y, z, rz)
 		local oil = createObject(2717, x, y, z, 90, 0, 0)
 		setObjectScale(oil, 2)
@@ -481,7 +490,7 @@ addEventHandler("dropOil", root,
 kamikazeTimer = {}
 preKamikazeTimer = {}
 addEvent("kamikazeMode", true)
-addEventHandler("kamikazeMode", root, 
+addEventHandler("kamikazeMode", resourceRoot, 
 	function()
 		local theVehicle = getPedOccupiedVehicle(client)
 		local marker = attachMarker(theVehicle, 6000, 255, 0, 0, 80)
@@ -530,7 +539,7 @@ addEventHandler("kamikazeMode", root,
 --------------------
 local speedMarkerColorTimer = {}
 addEvent("speedMode", true)
-addEventHandler("speedMode", root, 
+addEventHandler("speedMode", resourceRoot, 
 	function(speedItemTime)
 		local theVehicle = getPedOccupiedVehicle(client)
 		local marker = attachMarker(theVehicle, speedItemTime+200, 255, 125, 0, 80)
@@ -554,7 +563,7 @@ addEventHandler("speedMode", root,
 -- Fly Event --
 ---------------
 addEvent("flyMode", true)
-addEventHandler("flyMode", root, 
+addEventHandler("flyMode", resourceRoot, 
 	function(flyItemTime)
 		local theVehicle = getPedOccupiedVehicle(client)
 		attachMarker(theVehicle, flyItemTime+200, 125, 0, 125, 80)
@@ -566,7 +575,7 @@ addEventHandler("flyMode", root,
 -- Magnet Event --
 ------------------
 addEvent("doMagnet", true)
-addEventHandler("doMagnet", root, 
+addEventHandler("doMagnet", resourceRoot, 
 	function()
 	-----------for tests
 		--[[for k, victim in ipairs(getElementsByType("player")) do
@@ -640,7 +649,7 @@ addEventHandler("onElementDataChange", root,
 -- Repair Vehicle Event --
 --------------------------
 addEvent("fixVehicle", true)
-addEventHandler("fixVehicle", root, 
+addEventHandler("fixVehicle", resourceRoot, 
 	function(fix) 
 		local theVehicle = getPedOccupiedVehicle(client)
 		if fix then
@@ -657,7 +666,7 @@ addEventHandler("fixVehicle", root,
 -- Nitro Event --
 -----------------
 addEvent("giveNitro", true)
-addEventHandler("giveNitro", root, 
+addEventHandler("giveNitro", resourceRoot, 
 	function() 
 		local theVehicle = getPedOccupiedVehicle(client)
 		addVehicleUpgrade(theVehicle, 1010)
@@ -670,7 +679,7 @@ addEventHandler("giveNitro", root,
 -- Jump Event --
 ----------------
 addEvent("doJump", true)
-addEventHandler("doJump", root, 
+addEventHandler("doJump", resourceRoot, 
 	function()
 		local theVehicle = getPedOccupiedVehicle(client)
 		local x, y, z = getElementVelocity(theVehicle)
@@ -692,7 +701,7 @@ function attachMarker(theVehicle, timer, r, g, b, a)
 	return marker[player]
 end
 addEvent("attachMarker", true)
-addEventHandler("attachMarker", root, attachMarker)
+addEventHandler("attachMarker", resourceRoot, attachMarker)
 
 -----------------------
 -- Kills Information --
@@ -724,7 +733,7 @@ function startSound3D(sound)
 	triggerClientEvent(root, "create3DSound", resourceRoot, theVehicle, sound)
 end
 addEvent("startSound3D", true)
-addEventHandler("startSound3D", root, startSound3D)
+addEventHandler("startSound3D", resourceRoot, startSound3D)
 
 
 -------------
@@ -745,14 +754,14 @@ function preGiveMinigun()
 	bindKey(client, "lctrl", "both", preShootMinigun)
 end
 addEvent("preGiveMinigun", true)
-addEventHandler("preGiveMinigun", root, preGiveMinigun)
+addEventHandler("preGiveMinigun", resourceRoot, preGiveMinigun)
 
 function removeMinigun()
 	unbindKey(client, "mouse1", "both", preShootMinigun)
 	unbindKey(client, "lctrl", "both", preShootMinigun)
 end
 addEvent("removeMinigun", true)
-addEventHandler("removeMinigun", root, removeMinigun)
+addEventHandler("removeMinigun", resourceRoot, removeMinigun)
 
 
 --------------------------------------------

--- a/resources/[maps]/coremarkers/server.lua
+++ b/resources/[maps]/coremarkers/server.lua
@@ -4,7 +4,26 @@ local markersRespawn = 5000
 local marker = {}
 local markerTimer = {}
 local powerTypes = {}
-
+local fullPowerTypesList = {
+	"repair",
+	"spikes",
+	"boost",
+	"oil",
+	"hay",
+	"barrels",
+	"ramp",
+	"rocket",
+	"magnet",
+	"jump",
+	"rock",
+	"smoke",
+	"nitro",
+	"speed",
+	"fly",
+	"kmz",
+	"minigun",
+}
+					
 ------------------------
 -- Gamemode Detection --
 ------------------------
@@ -15,149 +34,180 @@ addEventHandler('onMapStarting', resourceRoot,
 		currentGameMode = string.upper(mapInfo.modename)
 		if currentGameMode == "DESTRUCTION DERBY" then
 			powerTypes = {
-					{"repair"},
-					{"spikes"},
-					--{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					--{"magnet"},
-					{"jump"},
-					{"rock"},
-					--{"smoke"},
-					{"nitro"},
-					--{"speed"},
-					--{"fly"},
-					--{"kmz"},
-					{"minigun"},
+					"repair",
+					"spikes",
+					--"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					--"magnet",
+					"jump",
+					"rock",
+					--"smoke",
+					"nitro",
+					--"speed",
+					--"fly",
+					--"kmz",
+					"minigun",
 			}
 		elseif currentGameMode == "FREEROAM" then --race
 			powerTypes = {
-					{"repair"},
-					{"spikes"},
-					{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					{"magnet"},
-					--{"jump"},
-					{"rock"},
-					{"smoke"},
-					{"nitro"},
-					{"speed"},
-					{"fly"},
-					{"kmz"},
-					{"minigun"},
+					"repair",
+					"spikes",
+					"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					"magnet",
+					--"jump",
+					"rock",
+					"smoke",
+					"nitro",
+					"speed",
+					"fly",
+					"kmz",
+					"minigun",
 			}
 		elseif currentGameMode == "SPRINT" then --also race
 			powerTypes = {
-					{"repair"},
-					{"spikes"},
-					{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					{"magnet"},
-					--{"jump"},
-					{"rock"},
-					{"smoke"},
-					{"nitro"},
-					{"speed"},
-					{"fly"},
-					{"kmz"},
-					{"minigun"},
+					"repair",
+					"spikes",
+					"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					"magnet",
+					--"jump",
+					"rock",
+					"smoke",
+					"nitro",
+					"speed",
+					"fly",
+					"kmz",
+					"minigun",
 			}
 		elseif currentGameMode == "CAPTURE THE FLAG" then
 			powerTypes = {
-					{"repair"},
-					{"spikes"},
-					{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					{"magnet"},
-					{"jump"},
-					{"rock"},
-					{"smoke"},
-					{"nitro"},
-					{"speed"},
-					{"fly"},
-					{"kmz"},
-					{"minigun"},
+					"repair",
+					"spikes",
+					"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					"magnet",
+					"jump",
+					"rock",
+					"smoke",
+					"nitro",
+					"speed",
+					"fly",
+					"kmz",
+					"minigun",
 			}
 		elseif currentGameMode == "REACH THE FLAG" then
 			powerTypes = {
-					{"repair"},
-					{"spikes"},
-					{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					{"magnet"},
-					{"jump"},
-					{"rock"},
-					{"smoke"},
-					{"nitro"},
-					{"speed"},
-					{"fly"},
-					--{"kmz"},
-					{"minigun"},
+					"repair",
+					"spikes",
+					"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					"magnet",
+					"jump",
+					"rock",
+					"smoke",
+					"nitro",
+					"speed",
+					"fly",
+					--"kmz",
+					"minigun",
 			}
 		elseif currentGameMode == "NEVER THE SAME" then
 			powerTypes = {
-					--{"repair"},
-					{"spikes"},
-					{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					{"magnet"},
-					--{"jump"},
-					{"rock"},
-					{"smoke"},
-					--{"nitro"},
-					{"speed"},
-					{"fly"},
-					{"kmz"},
-					{"minigun"},
+					--"repair",
+					"spikes",
+					"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					"magnet",
+					--"jump",
+					"rock",
+					"smoke",
+					--"nitro",
+					"speed",
+					"fly",
+					"kmz",
+					"minigun",
 			}
 		elseif currentGameMode == "SHOOTER" then
 			powerTypes = {
-					{"repair"},
-					{"spikes"},
-					{"boost"},
-					{"oil"},
-					{"hay"},
-					{"barrels"},
-					{"ramp"},
-					{"rocket"},
-					{"magnet"},
-					{"jump"},
-					{"rock"},
-					{"smoke"},
-					{"nitro"},
-					{"speed"},
-					{"fly"},
-					--{"kmz"},
-					{"minigun"},
+					"repair",
+					"spikes",
+					"boost",
+					"oil",
+					"hay",
+					"barrels",
+					"ramp",
+					"rocket",
+					"magnet",
+					"jump",
+					"rock",
+					"smoke",
+					"nitro",
+					"speed",
+					"fly",
+					--"kmz",
+					"minigun",
 			}
+		end
+				
+		local powerTypes2 = checkItemsListInMapSettings()
+		if powerTypes2 then
+			powerTypes = powerTypes2
 		end
 		triggerClientEvent(root, "getAllowedPowerTypes", resourceRoot, powerTypes)
 	end
 )
 
+function checkItemsListInMapSettings()
+	local powerTypesList = get(currentMap..".coremarkers_items")
+	if powerTypesList then
+		local powerTypesTemp = {}
+		for power in string.gmatch(powerTypesList, '([^,]+)') do
+			--outputChatBox(power)
+			local isPower = false
+			for i=1, #fullPowerTypesList do
+				if power == fullPowerTypesList[i] then
+					isPower = true
+				end
+			end
+			if isPower then
+				--outputChatBox(power.." - checked, correct")
+				table.insert(powerTypesTemp, power)
+			else
+				--outputChatBox("You have incorrect item '"..power.."' in your list, default items list will be used")
+				return false
+			end
+		end
+		if #powerTypesTemp ~= 0 then
+			return powerTypesTemp
+		end
+	end
+end
+		
 addEvent("requestAllowedPowerTypes", true)
 addEventHandler("requestAllowedPowerTypes", resourceRoot, 
 	function()

--- a/resources/[maps]/coremarkers/server.lua
+++ b/resources/[maps]/coremarkers/server.lua
@@ -188,8 +188,10 @@ addEventHandler("onResourceStart", resourceRoot,
 		local coremarkers = getElementsByType("coremarker")
 		if #coremarkers > 0 then --new way, coremarkers as elements placed into .map file using mrgreen map editor plugin
 			for _, element in ipairs(coremarkers) do
-				local x, y, z = getElementPosition(element)
-				spawnPickup(element, x, y, z)
+				if getElementType(getElementParent(element)) == "map" then --for map editor. 'mapContainer' parent means objects created by map editor, ignore them
+					local x, y, z = getElementPosition(element)
+					spawnPickup(element, x, y, z)
+				end
 			end
 		else --old way, coremarkers as solid boxes
 			for _, object in ipairs(getElementsByType("object")) do


### PR DESCRIPTION
**CoreMarkers HotFix v0.9.4**
- [BUG] fixed barrels not disappearing after explosion
- [MINOR][CODE] changed coremarkers events to be attached to resourceRoot instead of root so they can be triggered only by coremarkers resource

**Map Editor Tools Fixes for Map Tests**
- fixed EDF conflicts if using both mrgreen plugin and coremarkers (or nfsarrows)
- fixed mrgreen plugin to ignore map editor elements while testing and use only elements from map file (there was double coremarkers and random markers)
- fixed coremarkers to work correctly in map editor while testing map

**CoreMarkers: Custom Items List**
- Now mappers will be able to choose list of items used in the map. (Map Editor - Map Settings - Gamemode Settings)