### PR TITLE
[race_ghost] Disabled collisions for ghosts + [gcshop][GUI] Fixed maps search overlapping

### DIFF
--- a/resources/[gameplay]/gcshop/maps/maps_client.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_client.lua
@@ -56,7 +56,7 @@ function createNextmapWindow(tabPanel)
         guiLabelSetColor( tab.label5, 255, 0, 0 )
         guiSetFont( tab.label5, "default-bold-small" )
 
-        tab.viplabel = guiCreateLabel(0.03, 0.14, 0.50, 0.12, "Purchase VIP to get a free map every day!", true, tab.maps)
+        tab.viplabel = guiCreateLabel(0.03, 0.14, 0.36, 0.08, "Purchase VIP to get a free map every day!", true, tab.maps)
         guiLabelSetColor( tab.viplabel, 255, 0, 0 )
         guiSetFont( tab.viplabel, "default-bold-small" )
         guiSetFont( tab.viplabel, "default-bold-small" )

--- a/resources/[race]/race/override_client.lua
+++ b/resources/[race]/race/override_client.lua
@@ -71,6 +71,7 @@ function isCollideOthers ( element )
 end
 
 function isCollideWorld ( element )
+	if getElementData(element, "race.isGhostVehicle") == true then return false end
 	return ( getElementData ( element, 'race.collideworld' ) or 1 ) ~= 0
 end
 

--- a/resources/[race]/race_ghost/playback_local_client.lua
+++ b/resources/[race]/race_ghost/playback_local_client.lua
@@ -84,6 +84,7 @@ function LocalGhostPlayback:loadGhost(mapName)
 			if v.ty == "st" then
 				ped = createPed( v.p, v.x, v.y, v.z )
 				vehicle = createVehicle( v.m, v.x, v.y, v.z, v.rX, v.rY, v.rZ )
+				setElementData(vehicle, "race.isGhostVehicle", true)
 				blip = createBlipAttachedTo( ped, 0, 1, 150, 150, 150, 50 )
 				setElementParent( blip, ped )
 				warpPedIntoVehicle( ped, vehicle )

--- a/resources/[race]/race_ghost/playback_server.lua
+++ b/resources/[race]/race_ghost/playback_server.lua
@@ -89,6 +89,7 @@ function GhostPlayback:loadGhost()
 			if v.ty == "st" then
 				self.ped = createPed( v.p, v.x, v.y, v.z )
 				self.vehicle = createVehicle( v.m, v.x, v.y, v.z, v.rX, v.rY, v.rZ )
+				setElementData(self.vehicle, "race.isGhostVehicle", true)
 				self.blip = createBlipAttachedTo( self.ped, 0, 1, 150, 150, 150, 50 )
 				setElementParent( self.blip, self.ped )
 				warpPedIntoVehicle( self.ped, self.vehicle )


### PR DESCRIPTION
- [race_ghost] Ghosts won't hit objects now
- [gcshop] Maps-Center search box fix
![gcshop_fix](https://user-images.githubusercontent.com/13442966/75111328-adff1c00-5649-11ea-8a9b-250d4cea3b60.png)
P.S. Requires restart of "race", "race_ghost" and "gcshop" resources to apply changes.