### PR TITLE
Fixed small horns gridlists bug

### DIFF
--- a/resources/[gameplay]/gcshop/horns/horns_c.lua
+++ b/resources/[gameplay]/gcshop/horns/horns_c.lua
@@ -555,6 +555,9 @@ function onShopInit(tabPanel)
     addEventHandler("onClientGUIClick", sell, sellHorn, false)
     addEventHandler("onClientGUIClick", unlimited, unlimitedHorn, false)
     addEventHandler("onClientGUIChanged", search, hornSearchGuiChanged)
+	
+    guiBringToFront(availableHornsList)
+    guiBringToFront(myHornsList)
 end
 
 addEvent('onShopInit', true)


### PR DESCRIPTION
When you open the horns tab, you cannot select the very first row now. You need to randomly click around on the gridlist and then after 1min of frustrating clicking it might allow you to select the first row. This fixes that so that the first row is selectable from the first try.