### PR TITLE
Fix for next map window updating wrong when there is a bought map

### DIFF
--- a/resources/[race]/race/racevoting_server.lua
+++ b/resources/[race]/race/racevoting_server.lua
@@ -349,6 +349,14 @@ math.randomseed( getTickCount() % 50000 )
 currentmode = math.random(#modes)
 
 function calculateNextmap()
+	if exports.gcshop:isAnyMapQueued() then
+		local queuedMap = exports.gcshop:getCurrentMapQueued()
+		if queuedMap then
+			local queuedMapResource = getResourceFromName(queuedMap)
+			triggerEvent('onNextmapSettingChange', root, queuedMapResource)
+			return queuedMapResource
+		end
+	end
 	-- local chance = math.random(1,6)
 	local compatibleMaps
 	-- if chance == 2 or chance == 4 then


### PR DESCRIPTION
When there is a bought map but the current map gets played again, the next map window shows a random map's name instead of the bought map's name as next map. This aims to fix that.