### PR TITLE
Rank Board fixes

### DIFF
--- a/resources/[race]/race_rank/animation.lua
+++ b/resources/[race]/race_rank/animation.lua
@@ -1,4 +1,5 @@
 local anims, builtins = {}, {"Linear", "InQuad", "OutQuad", "InOutQuad", "OutInQuad", "InElastic", "OutElastic", "InOutElastic", "OutInElastic", "InBack", "OutBack", "InOutBack", "OutInBack", "InBounce", "OutBounce", "InOutBounce", "OutInBounce", "SineCurve", "CosineCurve"}
+local animKey = 0
 
 function table.find(t, v)
 	for k, a in ipairs(t) do
@@ -9,31 +10,39 @@ function table.find(t, v)
 	return false
 end
 
+function createAnimationKey()
+	animKey = animKey + 1
+	if animKey > 100000 then animKey = 1 end
+	return "k" .. animKey
+end
+
+
 function animate(f, t, easing, duration, onChange, onEnd)
 	assert(type(f) == "number", "Bad argument @ 'animate' [expected number at argument 1, got "..type(f).."]")
 	assert(type(t) == "number", "Bad argument @ 'animate' [expected number at argument 2, got "..type(t).."]")
 	assert(type(easing) == "string" or (type(easing) == "number" and (easing >= 1 or easing <= #builtins)), "Bad argument @ 'animate' [Invalid easing at argument 3]")
 	assert(type(duration) == "number", "Bad argument @ 'animate' [expected function at argument 4, got "..type(duration).."]")
 	assert(type(onChange) == "function", "Bad argument @ 'animate' [expected function at argument 5, got "..type(onChange).."]")
-	table.insert(anims, {from = f, to = t, easing = table.find(builtins, easing) and easing or builtins[easing], duration = duration, start = getTickCount( ), onChange = onChange, onEnd = onEnd})
-	return #anims
+	local key = createAnimationKey()
+	anims[key] = {from = f, to = t, easing = table.find(builtins, easing) and easing or builtins[easing], duration = duration, start = getTickCount( ), onChange = onChange, onEnd = onEnd}
+	return key
 end
 
 function destroyAnimation(a)
 	if anims[a] then
-		table.remove(anims, a)
+		anims[a] = nil
 	end
 end
 
 addEventHandler("onClientRender", root, function( )
 	local now = getTickCount( )
-	for k,v in ipairs(anims) do
+	for k,v in pairs(anims) do
 		v.onChange(interpolateBetween(v.from, 0, 0, v.to, 0, 0, (now - v.start) / v.duration, v.easing))
 		if now >= v.start+v.duration then
 			if type(v.onEnd) == "function" then
 				v.onEnd( )
 			end
-			table.remove(anims, k)
+			anims[k] = nil
 		end
 	end
 end)

--- a/resources/[race]/race_rank/board_c.lua
+++ b/resources/[race]/race_rank/board_c.lua
@@ -141,7 +141,7 @@ function RankBoard:update(what)
 			--self.splitTime = getTickCount()
 		elseif key == "state" then
 			if value == "dead" then
-				self.a = 0.6
+				self.a = 0.5
 			elseif self.state == "dead" then
 				self.a = 1
 			end
@@ -228,7 +228,7 @@ function RankBoard:draw()
 	local teamColor = (alpha>0 and alpha<1) and tocolor(self.colorRGB[1], self.colorRGB[2], self.colorRGB[3], 255*alpha) or self.color
 	
 	local bgcolor = nil
-	local bgalpha = 255 * RankBoard.backgroundOpacity * alpha
+	local bgalpha = 255 * RankBoard.backgroundOpacity * (self.state == "dead" and 1 or alpha)
 	if self.localPlayer then
 		bgcolor = self.state == "finished" and tocolor(20,80,20,bgalpha) or tocolor(40,40,40,bgalpha)
 	else
@@ -495,7 +495,7 @@ addEventHandler("serverSendGM",root,gameModeHandler)
 
 addEventHandler("onClientElementDataChange", root, function(dataName, old, new)
 	if getElementType(source) ~= "player" or not RankBoard.items[source] then return end
-	if dataName == "player state" and RankBoard.items[source].state ~= "finished" then
+	if dataName == "player state" and (new ~= "dead" or (new == "dead" and RankBoard.items[source].state ~= "finished")) then
 		RankBoard.items[source]:update({state = new})
 	elseif dataName == "vip.colorNick" then
 		local name = new or getPlayerName(source)


### PR DESCRIPTION
- fix invisible and overlapped rank board items
- only fade the text in "dead" state - keep the background
- prevent "dead" state when already finished