### PR TITLE
Update sb_c.lua

### DIFF
--- a/resources/[gameplay]/mrgreen-sidebar/sb_c.lua
+++ b/resources/[gameplay]/mrgreen-sidebar/sb_c.lua
@@ -184,7 +184,7 @@ end
 
 
 function drawDateTime()
-	local timestring = FormatDate("h:i\nd/m/Y" )
+	local timestring = FormatDate("h:i\nd.m.Y" )
 
 	dxDrawText(timestring,_sidebarLeft,dateTimeTop,_sidebarLeft+sidebarWidth,sidebarTop+menuItemHeight,tocolor(255,255,255,255),timeDateTextScale,timeDateFont,"center","top",true,false,true)
 end


### PR DESCRIPTION
Changed date format to use dots as separators in the F1 sidebar. The valid date format for Europe is 19.09.2020 and the one for US is 09/19/2020. Right now it shows a mixture of both, using the EU format but with US separators and it's anyone's guess what date it is if both day and month fall between 1 and 12.