### PR TITLE
Update gui_c.lua

### DIFF
--- a/resources/[gameplay]/mrgreen-stats/gui_c.lua
+++ b/resources/[gameplay]/mrgreen-stats/gui_c.lua
@@ -187,7 +187,7 @@ function receiveStats(stats, player)
         -- Send player info to browser
         local playerObj = {}
         playerObj.name = safeString(stats.name)
-        playerObj.gc = stats.gc
+        playerObj.gc = comma_value(tonumber(stats.gc))
         playerObj.vip = stats.vip
         
         local countryCode = isElement(player) and getElementData(player, 'country') or false
@@ -292,3 +292,15 @@ function scoreboardClick ( row, x, y, columnName )
 	end
 end
 addEventHandler ( "onClientPlayerScoreboardClick", root, scoreboardClick )
+
+--http://lua-users.org/wiki/FormattingNumbers
+function comma_value(amount)
+    local formatted = amount
+    while true do
+        formatted, k = string.gsub(formatted, "^(-?%d+)(%d%d%d)", '%1 %2')
+        if k == 0 then
+            break
+        end
+    end
+    return formatted
+end


### PR DESCRIPTION
Removed the comma for thousands on the GC display in F10 stats. All other places where GC amount shows up there is a space separator, not a comma one.