### PR TITLE
Added a "Amount of replays" setting to the race resource

### DIFF
--- a/resources/[race]/race/meta.xml
+++ b/resources/[race]/race/meta.xml
@@ -155,7 +155,7 @@
 
         <setting name="*color" value="#D27350" friendlyname="Message color" group="Display" accept="*" examples="#FF0000,#776655" desc="Color of the Race chat box messages." />
 
-        <setting name="*nReplay" value="2" friendlyname="Amount of replays" group="Gameplay" desc="The amount of times a map can be replayed" />
+        <setting name="*nReplay" value="2" friendlyname="Amount of replays" accept="0-9" group="Gameplay" desc="The amount of times a map can be replayed" />
         
         <setting name="*hurrytime" value="15" friendlyname="Hurry time" accept="0-120" group="Gameplay" desc="Display HURRY! message this many seconds before the time runs out." />
 

--- a/resources/[race]/race/meta.xml
+++ b/resources/[race]/race/meta.xml
@@ -155,6 +155,8 @@
 
         <setting name="*color" value="#D27350" friendlyname="Message color" group="Display" accept="*" examples="#FF0000,#776655" desc="Color of the Race chat box messages." />
 
+        <setting name="*nReplay" value="2" friendlyname="Amount of replays" group="Gameplay" desc="The amount of times a map can be replayed" />
+        
         <setting name="*hurrytime" value="15" friendlyname="Hurry time" accept="0-120" group="Gameplay" desc="Display HURRY! message this many seconds before the time runs out." />
 
         <setting name="*timeafterfirstfinish" value="30" friendlyname="Finish race time" accept="0-120" group="Gameplay" desc="The number of seconds the race continues for after someone wins." />

--- a/resources/[race]/race/racevoting_server.lua
+++ b/resources/[race]/race/racevoting_server.lua
@@ -1,7 +1,7 @@
 --UPDATE 6th December 2011
 --NEW SETTING--
 --Number of play agains allowed consecutively!
-local maxPlayAgain = 2
+local maxPlayAgain = tonumber(get("*nReplay"))
 ---
 ---------------
 g_MapInfoList = {}

--- a/resources/[race]/race/racevoting_server.lua
+++ b/resources/[race]/race/racevoting_server.lua
@@ -1,9 +1,4 @@
---UPDATE 6th December 2011
---NEW SETTING--
---Number of play agains allowed consecutively!
-local maxPlayAgain = tonumber(get("*nReplay"))
----
----------------
+
 g_MapInfoList = {}
 
 
@@ -225,6 +220,8 @@ end
 
 function startNextMapVote()
 
+	local maxPlayAgain = getNumber("race.nReplay", 2)
+
 	exports.votemanager:stopPoll()
 
 	-- Handle forced nextmap setting
@@ -374,6 +371,7 @@ local lastPlayed
 addEvent('onMapStarting', true)
 addEventHandler('onMapStarting', getRootElement(),
 function()
+	local maxPlayAgain = getNumber("race.nReplay", 2)
 	g_ForcedNextMap = nil
 	local currentMap = exports.mapmanager:getRunningGamemodeMap()
 	if lastPlayed ~= currentMap then


### PR DESCRIPTION
Created a setting in the race resource to easily change the amount of times a map can be replayed.
Default is 2, so 3 rounds total