### PR TITLE
Added timeType to /blocker and /mute

### DIFF
--- a/resources/[admin]/admin/server/admin_server.lua
+++ b/resources/[admin]/admin/server/admin_server.lua
@@ -1,4 +1,4 @@
-﻿--[[**********************************
+--[[**********************************
 *
 *	Multi Theft Auto - Admin Panel
 *
@@ -883,10 +883,44 @@ addEventHandler ( "aPlayer", _root, function ( player, action, data, additional,
 		elseif ( action == "mute" )  then
 			if ( isPlayerMuted ( player ) ) then action = "un"..action end
 			local reason = data or ""
-			local seconds = tonumber(additional) and tonumber(additional) > 0 and tonumber(additional)
+			local duration = tonumber(additional) and tonumber(additional) > 0 and tonumber(additional)
+			local timeType = additional2
+
+			if action ~= "unmute" then
+				outputChatBox("Muting " .. getPlayerName(player) .. "#FF0000 for " .. (duration or "unlimited") .. " " .. (timeType or "seconds"),source, 255, 0, 0, true)
+			end
+
+			if duration then
+				if not timeType or timeType == "s" or timeType == "second" or timeType == "seconds" then
+					duration = duration
+				elseif timeType == "m" or timeType == "minute" or timeType == "minutes" then
+					duration = duration * 60
+				elseif timeType == "h" or timeType == "hour" or timeType == "hours" then
+					duration = duration * 60 * 60
+				elseif timeType == "d" or timeType == "day" or timeType == "days" then
+					duration = duration * 60 * 60 * 24
+				elseif timeType == "w" or timeType == "week" or timeType == "weeks" then
+					duration = duration * 60 * 60 * 24 * 7
+				elseif timeType == "M" or timeType == "month" or timeType == "months" then
+					duration = duration * 60 * 60 * 24 * 31
+				elseif timeType == "y" or timeType == "year" or timeType == "years" then
+					duration = duration * 60 * 60 * 24 * 365
+				else
+					return outputChatBox("Invalid timetype", source, 255, 0, 0)
+				end
+			end
+
+
+			if isObjectInACLGroup( aclGetAccount ( source ), aclGetGroup ("Killers") ) and not isObjectInACLGroup( aclGetAccount ( source ), aclGetGroup ("Admin") ) then
+				if duration and duration > 86400 or not duration then
+					duration = 86400
+					outputChatBox("As a moderator you can mute someone for up to 24 hours", source, 255, 0, 0, true)
+				end
+			end
+
 			mdata = reason~="" and ( "(" .. reason .. ")" ) or ""
-			more = seconds and ( "(" .. secondsToTimeDesc(seconds) .. ")" ) or ""
-			aSetPlayerMuted ( player, not isPlayerMuted ( player ), seconds, source )
+			more = duration and ( "(" .. secondsToTimeDesc(duration) .. ")" ) or ""
+			aSetPlayerMuted ( player, not isPlayerMuted ( player ), duration, source )
 		elseif ( action == "freeze" )  then
 			if ( isPlayerFrozen ( player ) ) then action = "un"..action end
 			aSetPlayerFrozen ( player, not isPlayerFrozen ( player ) )

--- a/resources/[gameplay]/gus/blocker.lua
+++ b/resources/[gameplay]/gus/blocker.lua
@@ -5,7 +5,7 @@ local _blockerCache = {}
 local blockerDuration = 1000 * 60 * 60 * 1
 
 
-function blocker(player, _, nick, duration)
+function blocker(player, _, nick, duration, timeType)
 	local blockPlayer = findPlayerByName(nick)
 	if not blockPlayer then
 		outputChatBox("No player found", player, 0, 255,0)
@@ -15,9 +15,25 @@ function blocker(player, _, nick, duration)
 			duration = tonumber(duration)
 			if not duration then
 				duration = 1
+			elseif not timeType or timeType == "h" or timeType == "hour" or timeType == "hours" then
+				duration = duration
+			elseif timeType == "d" or timeType == "day" or timeType == "days" then
+				duration = duration * 24
+			elseif timeType == "w" or timeType == "week" or timeType == "weeks" then
+				duration = duration * 24 * 7
+			elseif timeType == "M" or timeType == "month" or timeType == "months" then
+				duration = duration * 24 * 31
+			elseif timeType == "y" or timeType == "year" or timeType == "years" then
+				duration = duration * 24 * 365
+			else
+				return outputChatBox("Invalid timetype", player, 255, 0, 0, true)
 			end
-
+			
+			outputChatBox("Marking " .. getPlayerName(blockPlayer) .. "#FF0000 as blocker for " .. (duration or "1") .. " " .. (timeType or "hours"), player, 255, 0, 0 , true)
+			
+			-- Mods can mark someone as blocker for up to 24 hours
 			if duration > 24 and not hasObjectPermissionTo ( player, "command.serialblocker", false ) then
+				outputChatBox("As a moderator you can mark someone for up to 24 hours", player, 255, 0, 0, true)
 				duration = 24
 			end
 

--- a/resources/[gameplay]/gus/blocker.lua
+++ b/resources/[gameplay]/gus/blocker.lua
@@ -10,7 +10,8 @@ function blocker(player, _, nick, duration, timeType)
 	if not blockPlayer then
 		outputChatBox("No player found", player, 0, 255,0)
 	else
-
+		
+		outputChatBox("Marking " .. getPlayerName(blockPlayer) .. "#FF0000 as blocker for " .. (duration or "1") .. " " .. (timeType or "hours"), player, 255, 0, 0 , true)
 		if not getElementData(blockPlayer,"markedblocker") then
 			duration = tonumber(duration)
 			if not duration then
@@ -29,7 +30,6 @@ function blocker(player, _, nick, duration, timeType)
 				return outputChatBox("Invalid timetype", player, 255, 0, 0, true)
 			end
 			
-			outputChatBox("Marking " .. getPlayerName(blockPlayer) .. "#FF0000 as blocker for " .. (duration or "1") .. " " .. (timeType or "hours"), player, 255, 0, 0 , true)
 			
 			-- Mods can mark someone as blocker for up to 24 hours
 			if duration > 24 and not hasObjectPermissionTo ( player, "command.serialblocker", false ) then


### PR DESCRIPTION
Added timeType logic to /blocker and /mute allowing the following commands:
- /blocker Nick_026 2 days
- /blocker Cena 2 weeks
- /mute CBY lovely_person 2 years
- /mute Dubby reason 2 months

The following timeTypes are implemented
- s, second, seconds
- m, minute, minutes
- h, hour, hours
- d, day, days
- M, month, months
- y, year, years
/mute supports all timeTypes. /blocker supports starting from hours

If no timeType is given in a command the default logic will be used (/blocker: hour, /mute: seconds)
Mods still can set for up to 24 hours as it originally is

_Reload **gus** and **admin** resource when merging_