### PR TITLE
Discord Request: Let bot log top 10 finishers

### DIFF
--- a/resources/[misc]/[discord]/discord-events/events.lua
+++ b/resources/[misc]/[discord]/discord-events/events.lua
@@ -167,7 +167,7 @@ addEventHandler("onGamemodeMapStart", root,
 addEvent("onPlayerFinish")
 addEventHandler("onPlayerFinish", root,
     function (rank, time)
-        if rank > 3 then
+        if rank > 10 then
             return
         end
 


### PR DESCRIPTION
The bot now sends the top 10 finishers to Discord instead of the top 3

_Reload **Discord-events** resource when merging_