### PR TITLE
Removed "Music player" from the sidebar

### DIFF
--- a/resources/[gameplay]/mrgreen-sidebar/sb_c.lua
+++ b/resources/[gameplay]/mrgreen-sidebar/sb_c.lua
@@ -75,7 +75,6 @@ MenuItems = { -- Name, Icon
 	{name = "My Stats", event = "sb_showStats"},
 	{name = "Settings", event = "sb_showSettings"},
 	{name = "PM", event = "sb_showPM"},
-	{name = "Music Player", event = "sb_showMusicPlayer"},
 	{name = "Help", event = "sb_showHelp"}
 	
 }


### PR DESCRIPTION
Music Player is no longer used. Removed this item from the sidebar

_Reload **mrgreen-sidebar** when merging_