### PR TITLE
Admins can mute and unmute players while they are not online

### DIFF
--- a/resources/[admin]/admin/meta.xml
+++ b/resources/[admin]/admin/meta.xml
@@ -55,6 +55,8 @@
   <!--Exported Functions-->
   <export function="getPlayerCountry"/>
   <export function="aAddSerialUnmuteTimer"/>
+  <export function="serialmute" />
+  <export function="serialunmute" />
 
   <!--Required XML configs kept in /conf/ folder-->
   <config src="conf/interiors.xml" type="client" />

--- a/resources/[admin]/admin/server/admin_server.lua
+++ b/resources/[admin]/admin/server/admin_server.lua
@@ -1734,6 +1734,11 @@ function serialunmute(pAdmin, _, serial)
 		outputChatBox('Wrong serial. Syntax: /serialunmute [serial]', pAdmin, 255, 0,0)
 		return
 	end
+
+	local playerToUnmute = getPlayerFromSerial(serial)
+	if playerToUnmute then -- if player online -> unmute local player as well
+		setPlayerMuted( playerToUnmute, false)
+	end
 	
 	removeMuteFromDB(serial)
 	outputChatBox("Serial: " ..serial.. " has been unmuted by " ..getPlayerName(pAdmin):gsub("#%x%x%x%x%x%x",""), root, 255, 100, 0)

--- a/resources/[gameplay]/gus/admin.lua
+++ b/resources/[gameplay]/gus/admin.lua
@@ -238,6 +238,45 @@ function(player,cmd,...)
 end
 )
 
+addCommandHandler('addmute',
+function(player, cmd, ...)
+	if not (hasObjectPermissionTo(player, "function.banPlayer", false)) then
+		return
+	end
+
+	if not (arg[1]) then outputChatBox("State the player's full name (no color codes).", player) return end
+	if not (arg[2]) then outputChatBox("Wrong syntax. Use /addmute [name] [days]", player) return end
+
+	local days = arg[2]
+
+	local mutePlayerName = string.gsub(arg[1], '#%x%x%x%x%x%x', '' )
+	local theInfo = getSerial(mutePlayerName)
+	if theInfo then
+		local theSerial = theInfo.serial
+		exports.admin:serialmute(player, "", theSerial, days)
+	else outputChatBox("No player match. Try again", player)
+	end
+end
+)
+
+addCommandHandler('removemute',
+function(player, cmd, ...)
+	if not (hasObjectPermissionTo(player, "function.banPlayer", false)) then
+		return
+	end
+
+	if not (arg[1]) then outputChatBox("Wrong syntax. use /removemute [name]", player) return end
+
+	local mutePlayerName = string.gsub(arg[1], '#%x%x%x%x%x%x', '' )
+	local theInfo = getSerial(mutePlayerName)
+	if theInfo then
+		local theSerial = theInfo.serial
+		exports.admin:serialunmute(player, "", theSerial)
+	else outputChatBox("No player match. Try again", player)
+	end
+end
+)
+
 chat_is_disabled = false
 playerResponsible = nil
 


### PR DESCRIPTION
Admins can mute a player who is offline:
/addmute [nick] [days]
_Note that this function can only handle days_

Admin can unmute a player who is offline:
/removemute [nick]

nick equals the player's last known nickname

_Reload **gus** and **admin** resources when merging_