### PR TITLE
Third checkpoint functionality

### DIFF
--- a/resources/[gameplay]/third_checkpoint/c_client.lua
+++ b/resources/[gameplay]/third_checkpoint/c_client.lua
@@ -1,0 +1,41 @@
+local marker
+local blip
+
+function clearThirdCheckpoint()
+	if marker then destroyElement(marker) end
+	marker = nil
+	
+	if blip then destroyElement(blip) end
+	blip = nil
+end
+addEvent("clearThirdCheckpoint", true)
+addEventHandler("clearThirdCheckpoint", root, clearThirdCheckpoint)
+
+function setThirdCheckpoint(checkpoint, isFinish)
+	if marker then destroyElement(marker) end
+	if blip then destroyElement(blip) end
+
+	-- checkpoint object:
+	-- { position={x, y, z}, size=size, color={r, g, b}, type=type, vehicle=vehicleID, paintjob=paintjob, upgrades={...} } 
+	
+	-- For some reason older maps have a color boolean, changing it to default blue
+	if checkpoint.color == false then
+		checkpoint.color = {}
+		checkpoint.color[1] = 0;
+		checkpoint.color[2] = 0;
+		checkpoint.color[3] = 255;
+	end
+
+	marker = createMarker(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], checkpoint.type or "checkpoint", checkpoint.size, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3] , 255)
+
+	local icon;
+	if (isFinish) then
+		-- Finish icon
+		icon = 53
+	else icon = 0 end
+
+	blip = createBlip(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], icon, 1, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3])
+end
+addEvent("setThirdCheckpoint", true)
+addEventHandler("setThirdCheckpoint", root, setThirdCheckpoint)
+

--- a/resources/[gameplay]/third_checkpoint/c_client.lua
+++ b/resources/[gameplay]/third_checkpoint/c_client.lua
@@ -1,45 +1,59 @@
-local marker
-local blip
+local modes = {}
+modes["Sprint"] = true
+modes["Never the same"] = true
 
-function clearThirdCheckpoint()
-	if marker then destroyElement(marker) end
-	marker = nil
-	
-	if blip then destroyElement(blip) end
-	blip = nil
-end
-addEvent("clearThirdCheckpoint", true)
-addEventHandler("clearThirdCheckpoint", root, clearThirdCheckpoint)
-addCommandHandler("s", clearThirdCheckpoint)
-addCommandHandler("spec", clearThirdCheckpoint)
-addCommandHandler("spectate", clearThirdCheckpoint)
-addCommandHandler("Toggle spectator", clearThirdCheckpoint)
-addCommandHandler("afk", clearThirdCheckpoint)
+local checkpoints
 
-function setThirdCheckpoint(checkpoint, isFinish)
-	if marker then destroyElement(marker) end
-	if blip then destroyElement(blip) end
-
-	-- checkpoint object:
-	-- { position={x, y, z}, size=size, color={r, g, b}, type=type, vehicle=vehicleID, paintjob=paintjob, upgrades={...} } 
-	
-	-- For some reason older maps have a color boolean, changing it to default blue
-	if checkpoint.color == false then
-		checkpoint.color = {}
-		checkpoint.color[1] = 0;
-		checkpoint.color[2] = 0;
-		checkpoint.color[3] = 255;
+function onMapStart(mapInfo, mapOptions, gameOptions)
+	for i, player in ipairs(getElementsByType("player")) do
+		triggerClientEvent(player, "clearThirdCheckpoint", root)
 	end
 
-	marker = createMarker(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], checkpoint.type or "checkpoint", checkpoint.size, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3] , 255)
+	if not modes[exports.race:getRaceMode()] then return false end
 
-	local icon;
-	if (isFinish) then
-		-- Finish icon
-		icon = 53
-	else icon = 0 end
+	checkpoints = exports.race:getCheckPoints()
 
-	blip = createBlip(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], icon, 1, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3])
+	if checkpoints[3] then
+		for i, player in ipairs(getElementsByType("player")) do
+			triggerClientEvent(player, "setThirdCheckpoint", root, checkpoints[3])
+		end
+	end
+
 end
-addEvent("setThirdCheckpoint", true)
-addEventHandler("setThirdCheckpoint", root, setThirdCheckpoint)
+addEventHandler("onMapStarting", getRootElement(), onMapStart)
+
+function onPlayerJoin()
+	if not modes[exports.race:getRaceMode()] then return false end
+
+	if checkpoints[3] then
+		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[3])
+	end
+end
+addEventHandler("onPlayerJoin", root, onPlayerJoin)
+
+function onPlayerReachCheckpoint(cp)
+	if not modes[exports.race:getRaceMode()] then return false end
+
+	if checkpoints[cp + 3] then
+		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[cp + 3], not checkpoints[cp + 4])
+	else
+		triggerClientEvent(source, "clearThirdCheckpoint", root)
+	end
+end
+addEventHandler("onPlayerReachCheckpoint", root, onPlayerReachCheckpoint)
+
+function onPlayerSpawn()
+	if not modes[exports.race:getRaceMode()] then return false end
+	setTimer(function(player)
+		local cpId = getElementData(player, "race.checkpoint")
+
+		if not cpId then return false end
+		
+		if checkpoints[cpId + 2] then
+			triggerClientEvent(player, "setThirdCheckpoint", root, checkpoints[cpId + 2], not checkpoints[cpId + 3])
+		else
+			triggerClientEvent(player, "clearThirdCheckpoint", root)
+		end
+	end, 100, 1, source)
+end
+addEventHandler("onPlayerSpawn", root, onPlayerSpawn)

--- a/resources/[gameplay]/third_checkpoint/c_client.lua
+++ b/resources/[gameplay]/third_checkpoint/c_client.lua
@@ -10,6 +10,11 @@ function clearThirdCheckpoint()
 end
 addEvent("clearThirdCheckpoint", true)
 addEventHandler("clearThirdCheckpoint", root, clearThirdCheckpoint)
+addCommandHandler("s", clearThirdCheckpoint)
+addCommandHandler("spec", clearThirdCheckpoint)
+addCommandHandler("spectate", clearThirdCheckpoint)
+addCommandHandler("Toggle spectator", clearThirdCheckpoint)
+addCommandHandler("afk", clearThirdCheckpoint)
 
 function setThirdCheckpoint(checkpoint, isFinish)
 	if marker then destroyElement(marker) end
@@ -38,4 +43,3 @@ function setThirdCheckpoint(checkpoint, isFinish)
 end
 addEvent("setThirdCheckpoint", true)
 addEventHandler("setThirdCheckpoint", root, setThirdCheckpoint)
-

--- a/resources/[gameplay]/third_checkpoint/meta.xml
+++ b/resources/[gameplay]/third_checkpoint/meta.xml
@@ -1,0 +1,5 @@
+<meta>
+	<info name="Third checkpoint" description="In race type gamemodes: Renders the third checkpoint" author="Nick_026" type="script" addon="race" version="1.0" />
+	<script src="c_client.lua" type="client" />
+	<script src="s_server.lua" type="server" />
+</meta>

--- a/resources/[gameplay]/third_checkpoint/s_server.lua
+++ b/resources/[gameplay]/third_checkpoint/s_server.lua
@@ -1,0 +1,57 @@
+local modes = {}
+modes["Sprint"] = true
+modes["Never the same"] = true
+
+local checkpoints
+
+function onMapStart(mapInfo, mapOptions, gameOptions)
+	for i, player in ipairs(getElementsByType("player")) do
+		triggerClientEvent(player, "clearThirdCheckpoint", root)
+	end
+
+	if not modes[exports.race:getRaceMode()] then return false end
+
+	checkpoints = exports.race:getCheckPoints()
+
+	if checkpoints[3] then
+		for i, player in ipairs(getElementsByType("player")) do
+			triggerClientEvent(player, "setThirdCheckpoint", root, checkpoints[3])
+		end
+	end
+
+end
+addEventHandler("onMapStarting", getRootElement(), onMapStart)
+
+function onPlayerJoin()
+	if not modes[exports.race:getRaceMode()] then return false end
+
+	if checkpoints[3] then
+		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[3])
+	end
+end
+addEventHandler("onPlayerJoin", root, onPlayerJoin)
+
+function onPlayerReachCheckpoint(cp)
+	if checkpoints[cp + 3] then
+		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[cp + 3], not checkpoints[cp + 4])
+	else
+		triggerClientEvent(source, "clearThirdCheckpoint", root)
+	end
+end
+addEventHandler("onPlayerReachCheckpoint", root, onPlayerReachCheckpoint)
+
+function onPlayerWasted()
+	-- cpId is the checkpoint number the player is heading to when dying
+	-- The player will be thrown 1 cp back (except when cpId is 1)
+	-- So the third checkpoint is cpId + 1
+	local cpId = getElementData(source, "race.checkpoint")
+
+	if cpId == 1 then return end
+
+	if checkpoints[cpId + 1] then
+		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[cpId + 1])
+	else 
+		triggerClientEvent(source, "clearThirdCheckpoint", root)
+	end
+end
+addEventHandler("onPlayerWasted", root, onPlayerWasted)

--- a/resources/[gameplay]/third_checkpoint/s_server.lua
+++ b/resources/[gameplay]/third_checkpoint/s_server.lua
@@ -32,6 +32,8 @@ end
 addEventHandler("onPlayerJoin", root, onPlayerJoin)
 
 function onPlayerReachCheckpoint(cp)
+	if not modes[exports.race:getRaceMode()] then return false end
+
 	if checkpoints[cp + 3] then
 		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[cp + 3], not checkpoints[cp + 4])
 	else
@@ -41,6 +43,7 @@ end
 addEventHandler("onPlayerReachCheckpoint", root, onPlayerReachCheckpoint)
 
 function onPlayerWasted()
+	if not modes[exports.race:getRaceMode()] then return false end
 	-- cpId is the checkpoint number the player is heading to when dying
 	-- The player will be thrown 1 cp back (except when cpId is 1)
 	-- So the third checkpoint is cpId + 1

--- a/resources/[gameplay]/third_checkpoint/s_server.lua
+++ b/resources/[gameplay]/third_checkpoint/s_server.lua
@@ -42,19 +42,16 @@ function onPlayerReachCheckpoint(cp)
 end
 addEventHandler("onPlayerReachCheckpoint", root, onPlayerReachCheckpoint)
 
-function onPlayerWasted()
+function onPlayerSpawn()
 	if not modes[exports.race:getRaceMode()] then return false end
-	-- cpId is the checkpoint number the player is heading to when dying
-	-- The player will be thrown 1 cp back (except when cpId is 1)
-	-- So the third checkpoint is cpId + 1
-	local cpId = getElementData(source, "race.checkpoint")
-
-	if cpId == 1 then return end
-
-	if checkpoints[cpId + 1] then
-		triggerClientEvent(source, "setThirdCheckpoint", root, checkpoints[cpId + 1])
-	else 
-		triggerClientEvent(source, "clearThirdCheckpoint", root)
-	end
+	setTimer(function(player)
+		local cpId = getElementData(player, "race.checkpoint")
+            
+		if checkpoints[cpId + 2] then
+			triggerClientEvent(player, "setThirdCheckpoint", root, checkpoints[cpId + 2], not checkpoints[cpId + 3])
+		else
+			triggerClientEvent(player, "clearThirdCheckpoint", root)
+		end
+	end, 100, 1, source)
 end
-addEventHandler("onPlayerWasted", root, onPlayerWasted)
+addEventHandler("onPlayerSpawn", root, onPlayerSpawn)


### PR DESCRIPTION
Players in Race and Never The Same can see up to 3 checkpoints at the same time:
![image](https://user-images.githubusercontent.com/33859387/108609668-b494b080-73cf-11eb-85fd-a8eab779aeb7.png)
The checkpoint is both rendered on the map and in the world