### PR TITLE
Toggle Between 2 and 3 Checkpoints

### DIFF
--- a/resources/[gameplay]/third_checkpoint/c_client.lua
+++ b/resources/[gameplay]/third_checkpoint/c_client.lua
@@ -1,6 +1,8 @@
 local marker
 local blip
 
+local enabled = isEnabledXML()
+
 function clearThirdCheckpoint()
 	if marker then destroyElement(marker) end
 	marker = nil
@@ -19,6 +21,7 @@ addCommandHandler("afk", clearThirdCheckpoint)
 function setThirdCheckpoint(checkpoint, isFinish, facing)
 	if marker then destroyElement(marker) end
 	if blip then destroyElement(blip) end
+	if not enabled then return false end;
 
 	-- checkpoint object:
 	-- { position={x, y, z}, size=size, color={r, g, b}, type=type, vehicle=vehicleID, paintjob=paintjob, upgrades={...} } 
@@ -32,7 +35,8 @@ function setThirdCheckpoint(checkpoint, isFinish, facing)
 	end
 
 	marker = createMarker(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], checkpoint.type or "checkpoint", checkpoint.size, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3] , 255)
-	
+
+
 	if facing and checkpoint.type == "ring" then
 		setMarkerTarget(marker, facing[1], facing[2], facing[3])
 	end
@@ -43,7 +47,22 @@ function setThirdCheckpoint(checkpoint, isFinish, facing)
 		icon = 53
 	else icon = 0 end
 
-	blip = createBlip(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], icon, 1, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3])
+	blip = createBlip(checkpoint.position[1], checkpoint.position[2], checkpoint.position[3], icon, 1, checkpoint.color[1], checkpoint.color[2], checkpoint.color[3], 255)
 end
 addEvent("setThirdCheckpoint", true)
 addEventHandler("setThirdCheckpoint", root, setThirdCheckpoint)
+
+function toggleEnabledDisabled()
+	enabled = not enabled
+
+	if not enabled then
+		outputChatBox("#00FF00[Checkpoints]#FFFFFF You can now see 2 checkpoints", 255, 255, 255, true)
+		clearThirdCheckpoint()
+	else
+		outputChatBox("#00FF00[Checkpoints]#FFFFFF When you hit the next checkpoint you can see 3 checkpoints", 255, 255, 255, true)
+	end
+
+	saveXML(enabled)
+end
+addCommandHandler("checkpoints", toggleEnabledDisabled)
+

--- a/resources/[gameplay]/third_checkpoint/helper.lua
+++ b/resources/[gameplay]/third_checkpoint/helper.lua
@@ -1,0 +1,39 @@
+function isEnabledXML()
+	local settingsXML = xmlLoadFile("/settings/settings.xml")
+	if not settingsXML then
+		settingsXML = xmlCreateFile("/settings/settings.xml", "settings")
+		xmlSaveFile(settingsXML)
+	else
+		local theChild = xmlFindChild(settingsXML, 'enabled', 0)
+		if theChild then
+			local xmlEnabled = xmlNodeGetValue(theChild)
+
+			return toboolean(xmlEnabled)
+		end
+	end
+	return true
+end
+
+function saveXML(enabled)
+	local settingsXML = xmlLoadFile("/settings/settings.xml")
+	local theChild = xmlFindChild(settingsXML, "enabled", 0)
+
+	if theChild then
+		xmlNodeSetValue(theChild, tostring(enabled))
+	else
+		local theNewChild = xmlCreateChild(settingsXML, "enabled")
+		xmlNodeSetValue(theNewChild, tostring(enabled))
+	end
+
+	xmlSaveFile(settingsXML)
+	xmlUnloadFile(settingsXML)
+end
+
+function toboolean( bool )
+    bool = tostring( bool )
+    if bool == "true" then
+        return true
+    elseif bool == "false" then
+        return false
+	end
+end

--- a/resources/[gameplay]/third_checkpoint/meta.xml
+++ b/resources/[gameplay]/third_checkpoint/meta.xml
@@ -1,5 +1,6 @@
 <meta>
 	<info name="Third checkpoint" description="In race type gamemodes: Renders the third checkpoint" author="Nick_026" type="script" addon="race" version="1.0" />
+	<script src="helper.lua" type="client" />
 	<script src="c_client.lua" type="client" />
 	<script src="s_server.lua" type="server" />
 </meta>


### PR DESCRIPTION
As requested:
Players can now toggle between seeing 2 or 3 checkpoints using the /checkpoints command.
This 'setting' is saved locally, so no need to do this every time a player joins