### PR TITLE
Visual Bug for Votes

### DIFF
--- a/resources/[managers]/votemanager/votemanager_server.lua
+++ b/resources/[managers]/votemanager/votemanager_server.lua
@@ -151,6 +151,9 @@ function startPoll(pollData)
 
 	--prepare to end the poll
 	pollTimer = setTimer(endPoll, activePoll.timeout * 1000, 1)
+
+	-- Recheck votes to reset amount of votes for client to avoid visual bug
+	recheckVotes()
 	return true
 end
 


### PR DESCRIPTION
Whenever a new vote starts the results of the previous vote are still visible until someone votes. 

Now when a vote starts all options properly reset to 0