### PR TITLE
Allows changing position of speed-o-meter

### DIFF
--- a/resources/[gameplay]/helpmenu/commands.txt
+++ b/resources/[gameplay]/helpmenu/commands.txt
@@ -72,7 +72,6 @@ B       - Toggle spectator.
 /mapflash                                           To enable or disable flashing icon on taskbar when next map starts.
 /maps                                               List of the maps we have (in console = F8).
 /messages                                           Disable F3 messaging to you.
-/mode                                               Change the mode for speedo.
 /nick [name]                                        Set player name.
 /oldcam                                             Switch to different camera.
 /players [mix/race]                                 Show players on other server.
@@ -96,9 +95,12 @@ B       - Toggle spectator.
 /toggleicon                                         Toggle typing icon.
 /upload                                             Show upload address.
 /getpackets [player]                                Show's if a player is lagging (anything above %0.0 considered as a lag number).
-/language                                           Allows you to select your langauge.
+/language                                           Allows you to select your language.
 /f /f [player]                                      Pays your respects.
 
+/mode                                               Change the mode for speedo.
+/speedx												Change the x offset for speedo.
+/speedy												Change the y offset for speedo.
 
 -------------------------------> Mods <-------------------------------
 
@@ -133,7 +135,7 @@ For example the following command mutes me for 30 minutes:
 /unbanip [ip] -- Unbans the IP.
 /unbanserial [serial] -- Unbans the serial.
 /kick [playerName] -- Kicks the player.
-/shout [playerName] [message] -- Shouts the message accross the player's screen.
+/shout [playerName] [message] -- Shouts the message across the player's screen.
 /debuggc [player] -- Dump gc info.
 /adsay [text] -- Talk in private with other admins (tip: /bind i chatbox adsay).
 /sban [player] [reason] -- Serial ban a player for reason.

--- a/resources/[gameplay]/speed-o-meter/script.lua
+++ b/resources/[gameplay]/speed-o-meter/script.lua
@@ -17,25 +17,23 @@ function mph()
 			speednumber = math.floor(speednumber)
 			speed = tostring(speednumber.." Knots") 
 			x,y = guiGetScreenSize()
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 Knots", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-73.5 - offsetxSetting, 151.5 + offsetySetting, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 Knots", x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 		else
 		 xx,yy,zz = getElementVelocity(car)
 		 speednumber = getDistanceBetweenPoints3D(0,0,0,getElementVelocity(car))*100
 		 speednumber = math.floor(speednumber)
 		 speed = tostring(speednumber.." MPh") 
 		 x,y = guiGetScreenSize()
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 MPH", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-73.5 - offsetxSetting, 151.5 + offsetySetting, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 MPH", x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 		end
 	end	
 end
 
 function kmh()
-	outputDebugString("X: " .. offsetxSetting)
-	outputDebugString("Y: " .. offsetySetting)
 	local target = getCameraTarget()
 	car = getPedOccupiedVehicle(getLocalPlayer())
 	if target and getElementType(target) == "vehicle" then
@@ -49,18 +47,18 @@ function kmh()
 			speednumber = math.floor(speednumber)
 			speed = tostring(speednumber.." Knots") 
 			x,y = guiGetScreenSize()
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 Knots", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-73.5 - offsetxSetting, 151.5 + offsetySetting, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 Knots", x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 		else
 		 xx,yy,zz = getElementVelocity(car)
 		 speednumber = getDistanceBetweenPoints3D(0,0,0,getElementVelocity(car))*100*1.61
 		 speednumber = math.floor(speednumber)
 		 speed = tostring(speednumber.." KMh") 
 		 x,y = guiGetScreenSize()
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 KMH", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-73.5 - offsetxSetting, 151.5 + offsetySetting, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 KMH", x, y, x-72 - offsetxSetting, 150 + offsetySetting, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 	end	
 	end
 end
@@ -107,7 +105,7 @@ function(commandName, offsetx)
 	xmlSaveFile(node)
 	xmlUnloadFile(node)
 end
-)
+, false, false)
 
 addCommandHandler('speedY',
 function(commandName, offsety)
@@ -122,7 +120,7 @@ function(commandName, offsety)
 	xmlSaveFile(node)
 	xmlUnloadFile(node)
 end
-)
+, false, false)
 
 
 

--- a/resources/[gameplay]/speed-o-meter/script.lua
+++ b/resources/[gameplay]/speed-o-meter/script.lua
@@ -1,4 +1,8 @@
-	digital = dxCreateFont( "digital.ttf", 20 )
+digital = dxCreateFont( "digital.ttf", 20 )
+
+local offsetxSetting = 0
+local offsetySetting = 0
+
 function mph()
 	local target = getCameraTarget()
 	car = getPedOccupiedVehicle(getLocalPlayer())
@@ -13,18 +17,18 @@ function mph()
 			speednumber = math.floor(speednumber)
 			speed = tostring(speednumber.." Knots") 
 			x,y = guiGetScreenSize()
-		dxDrawText( speed, x, y, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x, y, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 Knots", x, y, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 Knots", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 		else
 		 xx,yy,zz = getElementVelocity(car)
 		 speednumber = getDistanceBetweenPoints3D(0,0,0,getElementVelocity(car))*100
 		 speednumber = math.floor(speednumber)
 		 speed = tostring(speednumber.." MPh") 
 		 x,y = guiGetScreenSize()
-		dxDrawText( speed, x, y, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x, y, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 MPH", x, y, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 MPH", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 		end
 	end	
 end
@@ -43,18 +47,18 @@ function kmh()
 			speednumber = math.floor(speednumber)
 			speed = tostring(speednumber.." Knots") 
 			x,y = guiGetScreenSize()
-		dxDrawText( speed, x, y, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x, y, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 Knots", x, y, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 Knots", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 		else
 		 xx,yy,zz = getElementVelocity(car)
 		 speednumber = getDistanceBetweenPoints3D(0,0,0,getElementVelocity(car))*100*1.61
 		 speednumber = math.floor(speednumber)
 		 speed = tostring(speednumber.." KMh") 
 		 x,y = guiGetScreenSize()
-		dxDrawText( speed, x, y, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x, y, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( "000 KMH", x, y, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetxSetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( "000 KMH", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 	end	
 	end
 end
@@ -88,6 +92,36 @@ function(commandName,par)
 end
 )
 
+addCommandHandler('speedX',
+function(commandName, offsetx)
+	node = xmlLoadFile("settings.xml")
+	if not node then
+		node = xmlCreateFile("settings.xml", "mynode")
+	end
+	if offsetx then
+		xmlNodeSetAttribute(node, "offsetx", offsetx)
+		offsetxSetting = offsetx
+	end
+	xmlSaveFile(node)
+	xmlUnloadFile(node)
+end
+)
+
+addCommandHandler('speedY',
+function(commandName, offsety)
+	node = xmlLoadFile("settings.xml")
+	if not node then
+		node = xmlCreateFile("settings.xml", "mynode")
+	end
+	if offsety then
+		xmlNodeSetAttribute(node, "offsety", offsety)
+		offsetySetting = offsety
+	end
+	xmlSaveFile(node)
+	xmlUnloadFile(node)
+end
+)
+
 
 
 addEventHandler('onClientResourceStart', getResourceRootElement(getThisResource()),
@@ -102,6 +136,13 @@ function()
 				elseif xmlNodeGetAttribute(node, "setting") == "none" then
 					removeEventHandler("onClientRender",getRootElement(), kmh)
 					removeEventHandler("onClientRender",getRootElement(), mph)
+				end
+
+				if xmlNodeGetAttribute(node, "offsety") then
+					offsetySetting = xmlNodeGetAttribute(node, "offsety")
+				end
+				if xmlNodeGetAttribute(node, "offsetx") then
+					offsetxSetting = xmlNodeGetAttribute(node, "offsetx")
 				end
 				xmlUnloadFile(node)
 		end		

--- a/resources/[gameplay]/speed-o-meter/script.lua
+++ b/resources/[gameplay]/speed-o-meter/script.lua
@@ -34,6 +34,8 @@ function mph()
 end
 
 function kmh()
+	outputDebugString("X: " .. offsetxSetting)
+	outputDebugString("Y: " .. offsetySetting)
 	local target = getCameraTarget()
 	car = getPedOccupiedVehicle(getLocalPlayer())
 	if target and getElementType(target) == "vehicle" then

--- a/resources/[gameplay]/speed-o-meter/script.lua
+++ b/resources/[gameplay]/speed-o-meter/script.lua
@@ -59,7 +59,7 @@ function kmh()
 		 speed = tostring(speednumber.." KMh") 
 		 x,y = guiGetScreenSize()
 		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-73.5, 151.5, tocolor ( 0, 0, 0, 150 ), 1, digital, "right", "bottom", false, false)
-		dxDrawText( speed, x - offsetxSetting, y + offsetxSetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
+		dxDrawText( speed, x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 255 ), 1, digital, "right", "bottom", false, false)
 		dxDrawText( "000 KMH", x - offsetxSetting, y + offsetySetting, x-72, 150, tocolor ( 255, 255, 255, 40 ), 1, digital, "right", "bottom", false, false)
 	end	
 	end


### PR DESCRIPTION
You can now change the position of the speed-o-meter using:
/speedX 500 - Moves speedometer 500 pixels to the left (use -500 to move right)
/speedY 200 - Moves speedometer 200 pixels to the bottom (use -200 to move up)

These settings are saved for the client