### PR TITLE
Disallows AFK People GC Farming

### DIFF
--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -105,7 +105,7 @@ function updatePlaytimes()
 		local minutes = math.floor((currentTick - jointick)/60)
 		outputDebugString("Playtime for " .. getPlayerName(p) .. " is " .. currentTick - jointick .. " ticks")
 		if isAFK then
-			setElementData(p, 'playtime',getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes) .. "#808080(AFK)")
+			setElementData(p, 'playtime',getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes) .. "#808080 (AFK)")
 		else
 			setElementData(p, 'playtime', getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
 		end

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -85,7 +85,7 @@ function updatePlaytimes()
 				jointick = currentTick
 			end
 			setElementData(p, 'jointick', jointick)
-		elseif currentTick - jointick >= aMin * 5 then -- TODO Mark hour back to 1 hour
+		elseif currentTick - jointick >= aMin * 60 then
 			hoursPlayed = hoursPlayed + 1
 			if isPlayerLoggedInGC(p) then
 				local hourstring, anotherString = " hours",  " another "
@@ -103,7 +103,6 @@ function updatePlaytimes()
 			setElementData(p, 'hoursPlayed', hoursPlayed)
 		end
 		local minutes = math.floor((currentTick - jointick)/60)
-		outputDebugString("Playtime for " .. getPlayerName(p) .. " is " .. currentTick - jointick .. " ticks")
 		if isAFK then
 			setElementData(p, 'playtime',getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes) .. "#808080 (AFK)")
 		else

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -80,7 +80,7 @@ function updatePlaytimes()
 			setElementData(p, 'jointick', currentTick)
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
-			jointick = math.floor(jointick + (timerInterval / 1000) - 1)
+			jointick = math.floor(jointick + (timerInterval / 1000) + 1)
 			if currentTick - jointick < 0 then
 				jointick = currentTick
 			end

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -80,7 +80,7 @@ function updatePlaytimes()
 			setElementData(p, 'jointick', currentTick)
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
-			jointick = jointick + (timerInterval / 1000)
+			jointick = math.floor(jointick + (timerInterval / 1000))
 			setElementData(p, 'jointick', jointick)
 		elseif currentTick - jointick >= aMin * 5 then -- TODO Mark hour back to 1 hour
 			hoursPlayed = hoursPlayed + 1
@@ -101,11 +101,7 @@ function updatePlaytimes()
 		end
 		local minutes = math.floor((currentTick - jointick)/60)
 		outputDebugString("Playtime for " .. getPlayerName(p) .. " is " .. currentTick - jointick .. " ticks")
-		if isAFK then
-			setElementData(p, 'playtime', "#808080" .. getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
-		else
-			setElementData(p, 'playtime', getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
-		end
+		setElementData(p, 'playtime', getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
 	end
 end
 setTimer(updatePlaytimes, timerInterval, 0) -- minuteTickAmount loop

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -81,7 +81,7 @@ function updatePlaytimes()
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
 			jointick = math.floor(jointick + (timerInterval / 1000))
-			if jointick < 0 then
+			if currentTick - jointick < 0 then
 				jointick = currentTick
 			end
 			setElementData(p, 'jointick', jointick)

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -100,7 +100,7 @@ function updatePlaytimes()
 			setElementData(p, 'hoursPlayed', hoursPlayed)
 		end
 		local minutes = math.floor((currentTick - jointick)/60)
-		outputDebugString("Playtime for " .. getPlayerName(p) .. " is " .. jointick .. " ticks")
+		outputDebugString("Playtime for " .. getPlayerName(p) .. " is " .. currentTick - jointick .. " ticks")
 		if isAFK then
 			setElementData(p, 'playtime', "#808080" .. getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
 		else

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -80,7 +80,7 @@ function updatePlaytimes()
 			setElementData(p, 'jointick', currentTick)
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
-			jointick = math.floor(jointick + (timerInterval / 1000))
+			jointick = math.floor(jointick + (timerInterval / 1000) - .5)
 			if currentTick - jointick < 0 then
 				jointick = currentTick
 			end

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -80,7 +80,7 @@ function updatePlaytimes()
 			setElementData(p, 'jointick', currentTick)
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
-			jointick = math.floor(jointick + (timerInterval / 1000) - .5)
+			jointick = math.floor(jointick + (timerInterval / 1000) - 1)
 			if currentTick - jointick < 0 then
 				jointick = currentTick
 			end

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -80,7 +80,7 @@ function updatePlaytimes()
 			setElementData(p, 'jointick', currentTick)
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
-			jointick = math.floor(jointick + (timerInterval / 1000) + 1)
+			jointick = jointick + (timerInterval / 1000)
 			if currentTick - jointick < 0 then
 				jointick = currentTick
 			end

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -101,7 +101,11 @@ function updatePlaytimes()
 		end
 		local minutes = math.floor((currentTick - jointick)/60)
 		outputDebugString("Playtime for " .. getPlayerName(p) .. " is " .. currentTick - jointick .. " ticks")
-		setElementData(p, 'playtime', getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
+		if isAFK then
+			setElementData(p, 'playtime',getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes) .. "#808080(AFK)")
+		else
+			setElementData(p, 'playtime', getElementData(p, 'hoursPlayed') .. ':' .. string.format('%02d', minutes))
+		end
 	end
 end
 setTimer(updatePlaytimes, timerInterval, 0) -- minuteTickAmount loop

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -80,7 +80,7 @@ function updatePlaytimes()
 			setElementData(p, 'jointick', currentTick)
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
-			jointick = jointick + timerInterval
+			jointick = jointick + (timerInterval / 1000)
 			setElementData(p, 'jointick', jointick)
 		elseif currentTick - jointick >= aMin * 5 then -- TODO Mark hour back to 1 hour
 			hoursPlayed = hoursPlayed + 1

--- a/resources/[gameplay]/gc/gc_rewards.lua
+++ b/resources/[gameplay]/gc/gc_rewards.lua
@@ -81,6 +81,9 @@ function updatePlaytimes()
 			setElementData(p, 'hoursPlayed', 0)
 		elseif isAFK then -- AFK Players can't earn playtime
 			jointick = math.floor(jointick + (timerInterval / 1000))
+			if jointick < 0 then
+				jointick = currentTick
+			end
 			setElementData(p, 'jointick', jointick)
 		elseif currentTick - jointick >= aMin * 5 then -- TODO Mark hour back to 1 hour
 			hoursPlayed = hoursPlayed + 1


### PR DESCRIPTION
Players whom are AFK no longer progress their Playtime, and thus eleminating the hourly GC Bonus Farming