### PR TITLE
Cooldown for Coremarkers Maps

### DIFF
--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -131,11 +131,16 @@ function(choice)
 	local racemode = getResourceInfo(getResourceFromName(choice[2]), "racemode") or "race"
     local isCoremarkers = isCoremarkersMap(choice[2])
 
-    outputDebugString("Is bought map coremarkers? " .. tostring(isCoremarkers))
+    if (isCoremarkers and not isCoremarkersBuyable()) then
+        local timeLeft = secondsToTimeDesc(getElementData(root, "coremarkersLastPurchaseUnix"))
+        outputChatBox("[Maps-Center] Coremarkers maps are on cooldown. " .. timeLeft .. " left!", source, 255, 0, 0)
+        return
+    end
 
     if isPlayerEligibleToBuy(source, choice) then
         if playerHasBoughtMap(source, choice) then
             queue(choice, source)
+            if (isCoremarkers) then setElementData(root, "coremarkersLastPurchaseUnix", getTimeStamp()) end
         else
 			local mapprice = source == lastWinner and (getGamemodePrice(racemode) / 100) * (100 - lastWinnerDiscount) or getGamemodePrice(racemode)
             local vipIsRunning = getResourceState( getResourceFromName( "mrgreen-vip" ) ) == "running"
@@ -169,6 +174,16 @@ function isCoremarkersMap(mapResourceName)
                 return true
             end
         end
+    end
+    return false
+end
+
+function isCoremarkersBuyable()
+    local cmLastPurchaseUnix = getElementData(root, "coremarkersLastPurchaseUnix") or 0
+    local unix = getTimestamp()
+
+    if unix - cmLastPurchaseUnix > cm_cooldownTime then
+        return true
     end
     return false
 end

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -10,7 +10,7 @@ prices["deadline"] = 175
 local PRICE = 1000
 local mp_maxBuyAmount = 3 -- Daily map buy amount
 local mp_cooldownTime = 360*60 -- Minutes of cooldown for specific maps
-local cm_cooldownTime = 60*60 -- Minutes of cooldown for coremarker maps
+local cm_cooldownTime = 2*60 -- Minutes of cooldown for coremarker maps
 local mp_staffMapFree = false -- Is map free for staff in ACL below
 local mp_staffACLNames = {
     'ServerManager',
@@ -140,7 +140,7 @@ function(choice)
     if isPlayerEligibleToBuy(source, choice) then
         if playerHasBoughtMap(source, choice) then
             queue(choice, source)
-            if (isCoremarkers) then setElementData(root, "coremarkersLastPurchaseUnix", getTimeStamp()) end
+            if (isCoremarkers) then setElementData(root, "coremarkersLastPurchaseUnix", getTimestamp()) end
         else
 			local mapprice = source == lastWinner and (getGamemodePrice(racemode) / 100) * (100 - lastWinnerDiscount) or getGamemodePrice(racemode)
             local vipIsRunning = getResourceState( getResourceFromName( "mrgreen-vip" ) ) == "running"

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -9,7 +9,8 @@ prices["deadline"] = 175
 
 local PRICE = 1000
 local mp_maxBuyAmount = 3 -- Daily map buy amount
-local mp_cooldownTime = 360*60 -- Minutes of cooldown
+local mp_cooldownTime = 360*60 -- Minutes of cooldown for specific maps
+local cm_cooldownTime = 60*60 -- Minutes of cooldown for coremarker maps
 local mp_staffMapFree = false -- Is map free for staff in ACL below
 local mp_staffACLNames = {
     'ServerManager',
@@ -128,6 +129,9 @@ function(choice)
     local isFreeMap = isPlayerStaff(source)
     if not isFreeMap and isDailyLimitReached(tostring(choice[2])) then return end -- Check for map bought amount if not admin
 	local racemode = getResourceInfo(getResourceFromName(choice[2]), "racemode") or "race"
+    local isCoremarkers = isCoremarkersMap(choice[2])
+
+    outputDebugString("Is bought map coremarkers? " .. isCoremarkers)
 
     if isPlayerEligibleToBuy(source, choice) then
         if playerHasBoughtMap(source, choice) then
@@ -152,6 +156,12 @@ end)
 
 function getGamemodePrice(gamemode)
 	return prices[gamemode] or PRICE
+end
+
+function isCoremarkersMap(mapResourceName)
+    local meta = xmlLoadFile(':'.. mapResourceName..'/meta.xml')
+    local metaString = xmlLoadString(meta)
+    return metaString.find('resource="coremarkers"')
 end
 
 function isDailyLimitReached(mapname)

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -159,9 +159,17 @@ function getGamemodePrice(gamemode)
 end
 
 function isCoremarkersMap(mapResourceName)
-    local meta = xmlLoadFile(':'.. mapResourceName..'/meta.xml')
-    local metaString = xmlLoadString(meta)
-    return metaString.find('resource="coremarkers"')
+    local meta = xmlLoadFile(':'.. mapResourceName..'/meta.xml', true)
+
+    local children = xmlNodeGetChildren(meta)
+    for _, child in ipairs(children) do
+        if xmlNodeGetName(child) == 'include' then
+            local includedResource = xmlNodeGetAttribute(child, 'resource')
+            if includedResource == 'coremarkers' then
+                return true
+            end
+        end
+    end
 end
 
 function isDailyLimitReached(mapname)

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -10,7 +10,7 @@ prices["deadline"] = 175
 local PRICE = 1000
 local mp_maxBuyAmount = 3 -- Daily map buy amount
 local mp_cooldownTime = 360*60 -- Minutes of cooldown for specific maps
-local cm_cooldownTime = 2*60 -- Minutes of cooldown for coremarker maps
+local cm_cooldownTime = 120*60 -- Minutes of cooldown for coremarker maps
 local mp_staffMapFree = false -- Is map free for staff in ACL below
 local mp_staffACLNames = {
     'ServerManager',
@@ -131,6 +131,7 @@ function(choice)
 	local racemode = getResourceInfo(getResourceFromName(choice[2]), "racemode") or "race"
     local isCoremarkers = isCoremarkersMap(choice[2])
 
+    -- Coremarkers cooldown guard clause
     if (isCoremarkers and not isCoremarkersBuyable()) then
         local timeLeft = secondsToTimeDesc(cm_cooldownTime - (getTimestamp() - getElementData(root, "coremarkersLastPurchaseUnix")))
         outputChatBox("[Maps-Center] Coremarkers maps are on cooldown. " .. timeLeft .. " left!", source, 255, 0, 0)

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -132,7 +132,7 @@ function(choice)
     local isCoremarkers = isCoremarkersMap(choice[2])
 
     if (isCoremarkers and not isCoremarkersBuyable()) then
-        local timeLeft = secondsToTimeDesc(getElementData(root, "coremarkersLastPurchaseUnix"))
+        local timeLeft = secondsToTimeDesc(cm_cooldownTime - (getTimestamp() - getElementData(root, "coremarkersLastPurchaseUnix")))
         outputChatBox("[Maps-Center] Coremarkers maps are on cooldown. " .. timeLeft .. " left!", source, 255, 0, 0)
         return
     end

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -131,7 +131,7 @@ function(choice)
 	local racemode = getResourceInfo(getResourceFromName(choice[2]), "racemode") or "race"
     local isCoremarkers = isCoremarkersMap(choice[2])
 
-    outputDebugString("Is bought map coremarkers? " .. isCoremarkers)
+    outputDebugString("Is bought map coremarkers? " .. tostring(isCoremarkers))
 
     if isPlayerEligibleToBuy(source, choice) then
         if playerHasBoughtMap(source, choice) then

--- a/resources/[gameplay]/gcshop/maps/maps_server.lua
+++ b/resources/[gameplay]/gcshop/maps/maps_server.lua
@@ -170,6 +170,7 @@ function isCoremarkersMap(mapResourceName)
             end
         end
     end
+    return false
 end
 
 function isDailyLimitReached(mapname)


### PR DESCRIPTION
Added a global cooldown for Coremarker Maps. 

A coremarker map can only be played once every 2 hours.