### PR TITLE
Disable beneficial perks during Events

### DIFF
--- a/resources/[gameplay]/cw_script/client/cw_client.lua
+++ b/resources/[gameplay]/cw_script/client/cw_client.lua
@@ -134,7 +134,7 @@ function updateDisplay()
                 dxDrawRectangle(wX, wY + (rowHeight*(2+(count+1))), windowSizeX, rowHeight, tocolor(r2, g2, b2, 30), false, false) -- t2 bg
             end
 			dxDrawBottomRoundedRectangle(wX, wY + (rowHeight * (rowCount-1)), windowSizeX, rowHeight, 10, tocolor(0, 0, 0, 160), false, false) -- mode bg
-			dxDrawText("Press #bababaF7 #ffffffto change mode", wX, wY + (rowHeight * (rowCount-1)), wX+windowSizeX, wY + (rowHeight * (rowCount)), tocolor(255, 255, 255, 200), 1, fBold, "center", "center", false, false, true, true, false)
+			dxDrawText("Press #bababa0 #ffffffto change mode", wX, wY + (rowHeight * (rowCount-1)), wX+windowSizeX, wY + (rowHeight * (rowCount)), tocolor(255, 255, 255, 200), 1, fBold, "center", "center", false, false, true, true, false)
 
 			dxDrawText(sColor..state, wX, wY, wX+windowSizeX, wY+rowHeight, tocolor(255, 255, 255, 255), 1, fBold, "center", "center", false, false, true, true, false)
 			dxDrawText("Round "..c_round.."/"..m_round, wX, wY+rowHeight, wX+windowSizeX, wY+(rowHeight*2), tocolor(255, 255, 255, 255), 1, fBold, "center", "center", false, false, true, true, false)
@@ -192,7 +192,7 @@ function updateDisplay()
 			dxDrawRoundedRectangle(wX, wY, windowSizeX, windowSizeY, 10, tocolor(0, 0, 0, 160), false, false) -- background
 			dxDrawRectangle(wX, wY + (rowHeight*2), windowSizeX, rowHeight, tocolor(r1, g1, b1, 20), false, false) -- t1 bg
 			dxDrawBottomRoundedRectangle(wX, wY + (rowHeight * (rowCount-1)), windowSizeX, rowHeight, 10, tocolor(0, 0, 0, 160), false, false) -- mode bg
-			dxDrawText("Press #bababaF7 #ffffffto change mode", wX, wY + (rowHeight * (rowCount-1)), wX+windowSizeX, wY + (rowHeight * (rowCount)), tocolor(255, 255, 255, 200), 1, fBold, "center", "center", false, false, true, true, false)
+			dxDrawText("Press #bababa0 #ffffffto change mode", wX, wY + (rowHeight * (rowCount-1)), wX+windowSizeX, wY + (rowHeight * (rowCount)), tocolor(255, 255, 255, 200), 1, fBold, "center", "center", false, false, true, true, false)
 			dxDrawText(sColor..state, wX, wY, wX+windowSizeX, wY+rowHeight, tocolor(255, 255, 255, 255), 1, fBold, "center", "center", false, false, true, true, false)
 			dxDrawText("Round "..c_round.."/"..m_round, wX, wY+rowHeight, wX+windowSizeX, wY+(rowHeight*2), tocolor(255, 255, 255, 255), 1, fBold, "center", "center", false, false, true, true, false)
 			dxDrawText(t1c..t1tag.."   "..getElementData(teams[1], 'Score').."  #ffffff-  "..t2c..getElementData(teams[2], 'Score').."   "..t2tag, wX + margin, wY + (rowHeight*2), wX+windowSizeX-(margin*2), wY+(rowHeight*3), tocolor(r1, g1, b1, 255), 1, fBold, "center", "center", false, false, false, true, false)
@@ -513,10 +513,10 @@ function startWar()
     local ffa = guiCheckBoxGetSelected(ffa_field) == true and "FFA" or "CW"
 
 	serverCall('startWar', t1name, t2name, t1tag, t2tag, r1, g1, b1, r2, g2, b2, ffa)
-	outputInfoClient('Press #9b9bffF7 #ffffffto switch display mode')
+	outputInfoClient('Press #9b9bff0 #ffffffto switch display mode')
 
     if ffa == "CW" then
-        outputInfoClient('Press #9b9bffF6 #ffffffto select team')
+        outputInfoClient('Press #9b9bff8 #ffffffto select team')
     end
 end
 
@@ -561,7 +561,7 @@ function updateAdminInfo(obj)
 	isAdmin = obj
 	if isAdmin then
 		createAdminGUI()
-		outputInfoClient('Press #9b9bffF10 #ffffffto open management panel')
+		outputInfoClient('Press #9b9bff9 #ffffffto open management panel')
 	end
 end
 
@@ -590,9 +590,9 @@ setTimer(function()
         createGUI(getTeamName(teams[1]), getTeamName(teams[2]))
     end
 end, 2500, 1)
-bindKey('F6', 'down', toogleGUI)
-bindKey('F10', 'down', toogleAdminGUI)
-bindKey('F7', 'down', toggleMode)
+bindKey('8', 'down', toogleGUI)
+bindKey('9', 'down', toogleAdminGUI)
+bindKey('0', 'down', toggleMode)
 serverCall('playerJoin', localPlayer)
 
 ----------------------------

--- a/resources/[gameplay]/cw_script/client/cw_client.lua
+++ b/resources/[gameplay]/cw_script/client/cw_client.lua
@@ -28,7 +28,7 @@ local rankWidth = 40 * (screenW/1920)
 local ptsWidth = 50 * (screenW/1920)
 
 function outputInfoClient(info)
-    outputChatBox('[Event] #ffffff' ..info, player, 155, 155, 255, true)
+    outputChatBox('[Event] #ffffff' ..info, 155, 155, 255, true)
 end
 
 -----------------

--- a/resources/[gameplay]/cw_script/client/cw_client.lua
+++ b/resources/[gameplay]/cw_script/client/cw_client.lua
@@ -27,6 +27,10 @@ local nickWidth = 160 * (screenW/1920)
 local rankWidth = 40 * (screenW/1920)
 local ptsWidth = 50 * (screenW/1920)
 
+function outputInfoClient(info)
+    outputChatBox('[Event] #ffffff' ..info, player, 155, 155, 255, true)
+end
+
 -----------------
 -- Call functions
 -----------------
@@ -383,17 +387,17 @@ end
 function toggleMode()
 	if mode == "main" and ffa_mode == "CW" then
 		mode = "compact"
-		outputChatBox('[CW] #ffffffCompact mode', 155, 155, 255, true)
+		outputInfoClient('Compact mode')
 
     elseif mode == "main" and ffa_mode == "FFA" then
         mode = "hidden"
-        outputChatBox('[CW] #ffffffHidden mode', 155, 155, 255, true)
+        outputInfoClient('Hidden mode')
 	elseif mode == "compact" then
 		mode = "hidden"
-		outputChatBox('[CW] #ffffffHidden mode', 155, 155, 255, true)
+		outputInfoClient('Hidden mode')
 	else
 		mode = "main"
-		outputChatBox('[CW] #ffffffFull mode', 155, 155, 255, true)
+		outputInfoClient('Full mode')
 	end
 end
 
@@ -468,10 +472,10 @@ function zadatScoreRounds()
 
     local parsedScoring = stringToTable(scoring_value)
     if #parsedScoring ~= 0 then
-        outputChatBox('[CW] #ffffffScoring set to: ' .. table.concat(parsedScoring, ","), 155, 155, 255, true)
+        outputInfoClient('Scoring set to: ' .. table.concat(parsedScoring, ","))
         serverCall('updateScoring', scoring_value)
     else
-        outputChatBox('[CW] #FF0000INVALID SCORING, not applying scoring', 155, 155, 255, true)
+        outputInfoClient('#FF0000INVALID SCORING, not applying scoring', 155, 155, 255, true)
     end
 
 end
@@ -509,10 +513,10 @@ function startWar()
     local ffa = guiCheckBoxGetSelected(ffa_field) == true and "FFA" or "CW"
 
 	serverCall('startWar', t1name, t2name, t1tag, t2tag, r1, g1, b1, r2, g2, b2, ffa)
-	outputChatBox('[CW] #ffffffPress #9b9bffF7 #ffffffto switch display mode', 155, 155, 255, true)
+	outputInfoClient('Press #9b9bffF7 #ffffffto switch display mode')
 
     if ffa == "CW" then
-        outputChatBox('[CW] #ffffffPress #9b9bffF6 #ffffffto select team', 155, 155, 255, true)
+        outputInfoClient('Press #9b9bffF6 #ffffffto select team')
     end
 end
 
@@ -557,12 +561,7 @@ function updateAdminInfo(obj)
 	isAdmin = obj
 	if isAdmin then
 		createAdminGUI()
-		outputChatBox('[CW] #ffffffPress #9b9bffF10 #ffffffto open management panel', 155, 155, 255, true)
-        if getResourceFromName("gcshop") and getResourceState(getResourceFromName("gcshop")) == "running" then
-            outputChatBox('[CW] #ffffffGcShop perks are #00FF00ENABLED. #ffffffDisable them using /stop gcshop', 155, 155, 255, true)
-        else
-            outputChatBox('[CW] #ffffffGcShop perks are #FF0000DISABLED. #ffffffEnable them using /start gcshop', 155, 155, 255, true)
-        end
+		outputInfoClient('Press #9b9bffF10 #ffffffto open management panel')
 	end
 end
 
@@ -576,7 +575,7 @@ function stringToNumber(colorsString)
 	local g = gettok(colorsString, 2, string.byte(','))
 	local b = gettok(colorsString, 3, string.byte(','))
 	if r == false or g == false or b == false then
-		outputChatBox('[Race League]: use - [0-255], [0-255], [0-255]', 255, 155, 155, true)
+		outputInfoClient('use - [0-255], [0-255], [0-255]')
 		return 0, 255, 0
 	else
 		return r, g, b

--- a/resources/[gameplay]/cw_script/meta.xml
+++ b/resources/[gameplay]/cw_script/meta.xml
@@ -14,4 +14,5 @@
 	<file src="fonts/Roboto-Regular.ttf" />
 
     <export function="areTeamsSet" type="server" />
+    <export function="outputInfoForPlayer" type="server" />
 </meta>

--- a/resources/[gameplay]/cw_script/server/cw_server.lua
+++ b/resources/[gameplay]/cw_script/server/cw_server.lua
@@ -84,7 +84,7 @@ function preStart(player, command, t1_name, t2_name, t1tag, t2tag)
             end
 		end
 	else
-		outputChatBox('[CW] #ffffffYou are not admin', player, 155, 155, 255, true)
+		outputInfoForPlayer(player, 'You are not admin')
 	end
 end
 
@@ -101,7 +101,7 @@ function destroyTeams(player)
 			clientCall(player, 'updateRoundData', c_round, rounds, f_round)
 		end
 	else
-		outputChatBox('[CW] #ffffffYou are not admin', player, 155, 155, 255, true)
+		outputInfoForPlayer(player, 'You are not admin')
 	end
 end
 
@@ -111,9 +111,9 @@ function funRound(player)
 		for i,player in ipairs(getElementsByType('player')) do
 			clientCall(player, 'updateRoundData', c_round, rounds, f_round)
 		end
-		outputInfo('#ffffffFree round')
+		outputInfo('Free round')
 	else
-		outputChatBox('[CW] #ffffffYou are not admin', player, 155, 155, 255, true)
+		outputInfoForPlayer(player, 'You are not admin')
 	end
 end
 
@@ -124,8 +124,12 @@ addCommandHandler('fun', funRound)
 
 function outputInfo(info)
 	for i, player in ipairs(getElementsByType('player')) do
-		outputChatBox('[CW] #ffffff' ..info, player, 155, 155, 255, true)
+		outputInfoForPlayer(player, info)
 	end
+end
+
+function outputInfoForPlayer(player, info)
+    outputChatBox('[Event] #ffffff' ..info, player, 155, 155, 255, true)
 end
 
 function areTeamsSet()
@@ -443,7 +447,7 @@ addEventHandler('onElementDataChange', root, function(key, old, new)
     if key == 'player state' then
         local playerTeam = getPlayerTeam(source)
         if playerTeam == teams[3] and new == 'alive' and old ~= 'not ready' then
-            outputChatBox('[CW] #FF0000You\'re not allowed to play as Spectator', source, 155, 155, 255, true)
+            outputChatBox('[Event] #FF0000You\'re not allowed to play as Spectator', source, 155, 155, 255, true)
             exports.anti:forcePlayerSpectatorMode(source)
         end
     end

--- a/resources/[gameplay]/cw_script/server/cw_server.lua
+++ b/resources/[gameplay]/cw_script/server/cw_server.lua
@@ -447,7 +447,7 @@ addEventHandler('onElementDataChange', root, function(key, old, new)
     if key == 'player state' then
         local playerTeam = getPlayerTeam(source)
         if playerTeam == teams[3] and new == 'alive' and old ~= 'not ready' then
-            outputChatBox('[Event] #FF0000You\'re not allowed to play as Spectator', source, 155, 155, 255, true)
+            outputInfoForPlayer(source, '#FF0000You\'re not allowed to play as Spectator')
             exports.anti:forcePlayerSpectatorMode(source)
         end
     end

--- a/resources/[gameplay]/gcshop/items/burn/burn_s.lua
+++ b/resources/[gameplay]/gcshop/items/burn/burn_s.lua
@@ -62,6 +62,8 @@ function onVehicleDamage(loss)
 		return
 	elseif not isPerkAllowedInMode(ID) then
 		return
+    elseif getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
+        return
 	elseif isElement(veh) and getElementHealth(veh) - loss < 250 then
 		busy_with_player[player] = true
 		if not g_PlayersBurnExtra[player] then
@@ -76,27 +78,27 @@ addEventHandler('onVehicleDamage', root, onVehicleDamage)
 
 function resetBurnUpTime(player, times, marker, marker1)
 	if not (isElement(player) and getPedOccupiedVehicle(player) and isElement(getPedOccupiedVehicle(player)) and getElementHealth(getPedOccupiedVehicle(player)) < 250)
-		or getElementData(player,"race.finished") or (currentRaceState and currentRaceState ~= "Running" and currentRaceState ~= "SomeoneWon") or getElementData(player, 'state', false) ~= "alive" 
+		or getElementData(player,"race.finished") or (currentRaceState and currentRaceState ~= "Running" and currentRaceState ~= "SomeoneWon") or getElementData(player, 'state', false) ~= "alive"
 		then
 		busy_with_player[player] = nil
 		if isElement(marker) then destroyElement(marker) end
 		if isElement(marker1) then destroyElement(marker1) end
 		return
 	end
-	
+
 	busy_with_player[player] = true
 	local veh = getPedOccupiedVehicle(player)
 	setElementHealth(veh, 250)
 	setTimer(function(veh) if isElement(veh) then setElementHealth(veh,1)end end, 50, 1, veh)
-	
+
 	if not (marker and marker1 and isElement(marker) and isElement(marker1)) then
 		local px, py, pz = getElementPosition(veh)
 		marker = createMarker( px, py, pz, 'corona', 2);	setElementParent(marker, veh);	attachElements(marker, veh)
 		marker1 = createMarker( px, py, pz, 'corona', 2);	setElementParent(marker1, veh);	attachElements(marker1, veh)
 	end
-	
+
 	if type(times) ~= "number" or times <= 1 then
-		setTimer ( function(player, marker, marker1) 
+		setTimer ( function(player, marker, marker1)
 			busy_with_player[player] = nil
 			if isElement(marker) then destroyElement(marker) end
 			if isElement(marker1) then destroyElement(marker1) end
@@ -104,7 +106,7 @@ function resetBurnUpTime(player, times, marker, marker1)
 	else
 		setTimer ( resetBurnUpTime, extratime, 1, player, times - 1, marker, marker1 )
 	end
-	
+
 	exports.messages:outputGameMessage('You burned a little longer! ' .. (times or ''), player)
 end
 
@@ -136,58 +138,58 @@ local function getPlayerName(player)
 end
 
 -- function onPlayersVehicleCollide (player1, car1, player2, car2)
--- 	local saveFireHealth 
+-- 	local saveFireHealth
 -- 	if g_PlayersBurnTransfer[player1] and isPerkAllowedInMode(ID) and getElementHealth(car1) <= 245 and getElementHealth(car2) > 245 and not isVehicleBlown(car1) and not isVehicleBlown(car2) then  --isOnFire?
 -- 		saveFireHealth = getElementHealth(car1)
 -- 		fixVehicle(car1)
 -- 		setElementHealth(car1, getElementHealth(car2))
 -- 		setElementHealth(car2, saveFireHealth)    --transfer the fire !
-		
+
 -- 		outputChatBox('You have taken ' .. getPlayerName(player2).. '\'s health!', player1, 50, 202, 50)
 -- 		exports.messages:outputGameMessage('You have taken ' .. getPlayerName(player2).. '\'s health!', player1, 2, 50, 202, 50, true)
-		
+
 -- 		outputChatBox(getPlayerName(player1).. ' has given you his vehicle fire! (fire transfer gc perk)', player2, 50, 202, 50)
 -- 		exports.messages:outputGameMessage(getPlayerName(player1).. ' has given you his vehicle fire! ', player2,2, 50, 202, 50, true)
-		
+
 -- 	elseif g_PlayersBurnTransfer[player2] and isPerkAllowedInMode(ID) and getElementHealth(car2) <= 245 and getElementHealth(car1) > 245 and not isVehicleBlown(car1) and not isVehicleBlown(car2) then   --isOnFire
 -- 		saveFireHealth = getElementHealth(car2)
 -- 		--fixVehicle(car2)
 -- 		--setElementHealth(car2, getElementHealth(car1))
 -- 		setElementHealth(car1, saveFireHealth)	 --transfer the fire !
-		
+
 -- 		outputChatBox('You have taken ' .. getPlayerName(player1).. '\'s health!', player2, 50, 202, 50)
 -- 		exports.messages:outputGameMessage('You have taken ' .. getPlayerName(player1).. '\'s health!', player2, 2, 50, 202, 50, true)
-		
+
 -- 		outputChatBox(getPlayerName(player2).. ' has given you his vehicle fire! ', player1, 50, 202, 50)
 -- 		exports.messages:outputGameMessage(getPlayerName(player2).. ' has given you his vehicle fire! ', player1,2, 50, 202, 50, true)
--- 	end	
+-- 	end
 -- end
 function onPlayersVehicleCollide (player1, car1, player2, car2)
-	local saveFireHealth 
+	local saveFireHealth
 	if g_PlayersBurnTransfer[player1] and isPerkAllowedInMode(ID) and getElementHealth(car1) <= 245 and getElementHealth(car2) > 245 and not isVehicleBlown(car1) and not isVehicleBlown(car2) then  --isOnFire?
 		saveFireHealth = getElementHealth(car1)
 		fixVehicle(car1)
 		setElementHealth(car1, getElementHealth(car2))
 		setElementHealth(car2, saveFireHealth)    --transfer the fire !
-		
+
 		outputChatBox('You have taken ' .. getPlayerName(player2).. '\'s health!', player1, 50, 202, 50)
 		exports.messages:outputGameMessage('You have taken ' .. getPlayerName(player2).. '\'s health!', player1, 2, 50, 202, 50, true)
-		
+
 		outputChatBox(getPlayerName(player1).. ' has given you his vehicle fire! (fire transfer gc perk)', player2, 50, 202, 50)
 		exports.messages:outputGameMessage(getPlayerName(player1).. ' has given you his vehicle fire! ', player2,2, 50, 202, 50, true)
-		
+
 	elseif g_PlayersBurnTransfer[player2] and isPerkAllowedInMode(ID) and getElementHealth(car2) <= 245 and getElementHealth(car1) > 245 and not isVehicleBlown(car1) and not isVehicleBlown(car2) then   --isOnFire
 		saveFireHealth = getElementHealth(car2)
 		fixVehicle(car2)
 		setElementHealth(car2, getElementHealth(car1))
 		setElementHealth(car1, saveFireHealth)	 --transfer the fire !
-		
+
 		outputChatBox('You have taken ' .. getPlayerName(player1).. '\'s health!', player2, 50, 202, 50)
 		exports.messages:outputGameMessage('You have taken ' .. getPlayerName(player1).. '\'s health!', player2, 2, 50, 202, 50, true)
-		
+
 		outputChatBox(getPlayerName(player2).. ' has given you his vehicle fire! ', player1, 50, 202, 50)
 		exports.messages:outputGameMessage(getPlayerName(player2).. ' has given you his vehicle fire! ', player1,2, 50, 202, 50, true)
-	end	
+	end
 end
 addEvent('onPlayersVehicleCollide', true)
 addEventHandler('onPlayersVehicleCollide', root,onPlayersVehicleCollide)

--- a/resources/[gameplay]/gcshop/items/burn/burn_s.lua
+++ b/resources/[gameplay]/gcshop/items/burn/burn_s.lua
@@ -166,6 +166,7 @@ end
 -- end
 function onPlayersVehicleCollide (player1, car1, player2, car2)
 	local saveFireHealth
+    if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then return end
 	if g_PlayersBurnTransfer[player1] and isPerkAllowedInMode(ID) and getElementHealth(car1) <= 245 and getElementHealth(car2) > 245 and not isVehicleBlown(car1) and not isVehicleBlown(car2) then  --isOnFire?
 		saveFireHealth = getElementHealth(car1)
 		fixVehicle(car1)

--- a/resources/[gameplay]/gcshop/items/items_s.lua
+++ b/resources/[gameplay]/gcshop/items/items_s.lua
@@ -124,7 +124,7 @@ local perks = {
 --		local p = b.price
 --		b.price = math.ceil(p * d)
 --	end
---	
+--
 --	local players = getElementsByType("player")
 --	for a,b in ipairs(players) do
 --		local forumID = tonumber(exports.gc:getPlayerForumID(b))
@@ -135,13 +135,13 @@ local perks = {
 
 function onGCShopLogin (forumID)
 	local theSource = source
-	getPerks(forumID, 
+	getPerks(forumID,
 	function(prks)
 		local perkIdTable = {}
 		for _, p in pairs(prks) do
 			table.insert(perkIdTable, p.ID)
 		end
-		getPerkExpire(forumID, perkIdTable, 
+		getPerkExpire(forumID, perkIdTable,
 		function(expired)
 			local i = 1;
 			for _, perk in pairs(prks) do
@@ -156,12 +156,12 @@ function onGCShopLogin (forumID)
 				i * 500, 1, theSource, perk)
 				i = i + 1
 			end
-			getPerks(forumID, 
+			getPerks(forumID,
 			function(newPerks)
 				triggerClientEvent( theSource, 'itemLogin', theSource, perks, newPerks )
 				-- Trigger the event once more with a delay
 				setTimer(triggerClientEvent, 7500, 1, theSource, 'itemLogin', theSource, perks, newPerks)
-				
+
 			end)
 		end)
 	end)
@@ -170,8 +170,8 @@ addEventHandler("onGCShopLogin", root, onGCShopLogin)
 
 function onGCShopLogout (forumID)
 	local src = source
-	getPerks(forumID, 
-	function(perks) 
+	getPerks(forumID,
+	function(perks)
 		for _, perk in pairs(perks) do
 			unloadPerk(src, perk.ID)
 		end
@@ -181,12 +181,12 @@ addEventHandler("onGCShopLogout", root, onGCShopLogout)
 
 function buyPerk ( player, cmd, ID )
 	if client and client ~= player then return end
-	
+
 	ID = tonumber(ID)
 	local i = perks[ID]
-	
+
 	local forumID = tonumber(exports.gc:getPlayerForumID ( player ))
-	
+
 	if (not forumID) then
 		outputChatBox('You\'re not logged into a Green-Coins account!', player, 255, 0, 0 )
 		return
@@ -197,7 +197,7 @@ function buyPerk ( player, cmd, ID )
 		outputChatBox('Perk purchase has been disabled', player, 255, 0, 0 )
 		return
 	end
-	
+
 	-- Check if perk is already bought, and check for required perks
 	local idsToCheck = {ID}
 	if i.requires then
@@ -206,7 +206,7 @@ function buyPerk ( player, cmd, ID )
 		end
 	end
 
-	checkPerk(forumID, idsToCheck, 
+	checkPerk(forumID, idsToCheck,
 	function(res)
 		if res and res[ID] then
 			outputChatBox('You already bought this perk: '..i.description, player, 255, 165, 0 )
@@ -215,7 +215,7 @@ function buyPerk ( player, cmd, ID )
 			for _, perk in ipairs(i.requires) do
 				if not res[perk] then
 					outputChatBox('This perk requires another perk: '..perks[perk].description, player, 255, 0, 0 )
-					return			
+					return
 				end
 			end
 		end
@@ -229,9 +229,9 @@ function buyPerk ( player, cmd, ID )
 			addToLog ( '"' .. getPlayerName(player) .. '" (' .. tostring(forumID) .. ') bought perk=' .. tostring(ID) .. ' ' .. tostring(i.description) ..  ' ' .. tostring(i.defaultAmount) ..  ' ' .. tostring(added))
 			outputChatBox ('Perk \"' .. i.description  .. '\" bought.', player, 0, 255, 0)
 			loadPerk( player, ID )
-			getPerks(forumID, 
+			getPerks(forumID,
 			function(thePerks)
-				triggerClientEvent( player, 'itemLogin', player, perks, thePerks ) 
+				triggerClientEvent( player, 'itemLogin', player, perks, thePerks )
 			end)
 			return
 		end
@@ -247,12 +247,12 @@ addEventHandler('gcbuyperk', root, buyPerk)
 
 function buyPerkExtra ( player, cmd, ID, total )
 	if client and client ~= player then return end
-	
+
 	ID = tonumber(ID)
 	total = math.floor(total)
 	local i = perks[ID]
 	local forumID = tonumber(exports.gc:getPlayerForumID ( player ))
-	
+
 	if (not forumID) then
 		outputChatBox('You\'re not logged into a Green-Coins account!', player, 255, 0, 0 )
 		return
@@ -268,19 +268,19 @@ function buyPerkExtra ( player, cmd, ID, total )
 	end
 
 	local result, error = gcshopBuyItem ( player, i.price * total, 'Perk extra: ' .. i.description .. ' x' .. total )
-	
+
 	if result == true then
 		local theSource = source
-		getPerkSettings(player, ID, 
+		getPerkSettings(player, ID,
 		function(perkSetting)
-			setPerkSetting(player, ID, 'amount', perkSetting.amount + total, false, 
-			function(added) 
+			setPerkSetting(player, ID, 'amount', perkSetting.amount + total, false,
+			function(added)
 				addToLog ( '"' .. getPlayerName(player) .. '" (' .. tostring(forumID) .. ') bought extra perk=' .. tostring(ID) .. ' ' .. tostring(i.description) ..  ' ' .. tostring(i.defaultAmount) ..  ' ' .. tostring(total) ..  ' ' .. tostring(added))
 				outputChatBox ('Extra \"' .. i.description  .. '\" bought.', player, 0, 255, 0)
 				--loadPerk( player, ID )
-				
-				getPerks(forumID, 
-				function(res) 
+
+				getPerks(forumID,
+				function(res)
 					triggerClientEvent( theSource, 'itemLogin', theSource, perks, res )
 				end)
 			end)
@@ -332,13 +332,13 @@ function getPerks(forumID, callback)
 	end
 
 	dbQuery(
-		function(query) 
+		function(query)
 			local result = dbPoll(query,0)
 			local perkIdTable = {}
 			for _, prk in ipairs(result) do
 				table.insert(perkIdTable, prk.itembought)
 			end
-			getPerkExpire(forumID, perkIdTable, 
+			getPerkExpire(forumID, perkIdTable,
 			function(expired)
 				local return_perks = {}
 				for _, row in ipairs(result) do
@@ -351,7 +351,7 @@ function getPerks(forumID, callback)
 				end
 				callback(return_perks)
 			end)
-		end, 
+		end,
 	handlerConnect, "SELECT * FROM gc_items WHERE forumid=?", forumID)
 end
 
@@ -369,7 +369,7 @@ function checkPerk ( forumID, ID, callback )
 		end
 
 		dbQuery(
-			function(query) 
+			function(query)
 				local result = dbPoll(query,0)
 				if #result == 0 then
 					callback({})
@@ -382,14 +382,14 @@ function checkPerk ( forumID, ID, callback )
 					end
 				end
 				callback(returnVal)
-			end, 
+			end,
 		handlerConnect, "SELECT * FROM gc_items WHERE forumid=?", forumID)
 	else
 		dbQuery(
-			function(query) 
+			function(query)
 				local result = dbPoll(query,0)
 				callback(result and #result >= 1)
-			end, 
+			end,
 		handlerConnect, "SELECT * FROM gc_items WHERE forumid=? AND itembought=?", forumID, ID)
 	end
 end
@@ -399,7 +399,7 @@ function getPerkExpire ( forumID, ID, callback )
 	if type(callback) ~= 'function' then
 		outputDebugString( 'getPerkExpire: No callback specified at argument #3', 1 )
 		return
-	elseif not forumID then 
+	elseif not forumID then
 		callback(false)
 		-- outputDebugString('getPerkExpire: No forumID argument', 1)
 		return
@@ -411,7 +411,7 @@ function getPerkExpire ( forumID, ID, callback )
 			if ind == 1 then
 				queryString = queryString .. ' AND ('
 			end
-			
+
 			if prk and tonumber(prk) then
 				local addedQuery = dbPrepareString(handlerConnect, 'itembought = ?', prk)
 				if addedQuery then
@@ -426,7 +426,7 @@ function getPerkExpire ( forumID, ID, callback )
 			end
 		end
 		dbQuery(
-			function(query) 
+			function(query)
 				local result = dbPoll(query,0)
 				if result == false then
 					outputDebugString('Invalid query: '..queryString)
@@ -444,7 +444,7 @@ function getPerkExpire ( forumID, ID, callback )
 		handlerConnect, queryString)
 	else
 		dbQuery(
-			function(query) 
+			function(query)
 				local result = dbPoll(query,0)
 				callback(result and result[1].expires or nil)
 			end,
@@ -457,7 +457,7 @@ function loadPerk(player, ID)
 	getPerkSettings(player, ID,
 	function(perkSettings)
 		_G[perks[ID].func](player, true, perkSettings)
-		outputDebugString('Perk loaded: ' .. getPlayerName(player) .. ' ' .. ID .. ' ' .. perks[ID].description .. (tonumber(perkSettings.amount) and ' (' .. perkSettings.amount .. ')' or ''))		
+		outputDebugString('Perk loaded: ' .. getPlayerName(player) .. ' ' .. ID .. ' ' .. perks[ID].description .. (tonumber(perkSettings.amount) and ' (' .. perkSettings.amount .. ')' or ''))
 	end)
 end
 
@@ -468,7 +468,7 @@ function unloadPerk(player, ID)
 end
 
 function getPerkSettings(player, ID, callback)
-	
+
 	ID = tonumber(ID)
 	local i = perks[ID]
 	if type(callback) ~= 'function' then
@@ -521,21 +521,21 @@ function getPerkSettings(player, ID, callback)
 			return
 		end
 		dbQuery(
-			function(query) 
+			function(query)
 				local result = dbPoll(query,0)
 				local options = {}
 				if result[1] and result[1].options then
 					options = fromJSON(result[1].options)
 				end
-				if type(options) ~= 'table' then 
+				if type(options) ~= 'table' then
 					outputDebugString('GC Perks: wrong options format [' .. forumID, 1)
 					callback(false)
-					return  
+					return
 				end
 				callback(options)
-			end, 
+			end,
 		handlerConnect, "SELECT options FROM gc_items WHERE forumid=? AND itembought=?", forumID, ID)
-		
+
 	end
 end
 
@@ -548,7 +548,7 @@ function setPerkSetting(player, ID, key, value, text, callback)
 	ID = tonumber(ID)
 	local i = perks[ID]
 	local forumID = tonumber(exports.gc:getPlayerForumID ( player ))
-	checkPerk ( forumID, ID, 
+	checkPerk ( forumID, ID,
 	function(bool)
 		if not bool then
 			callback(false)
@@ -559,24 +559,24 @@ function setPerkSetting(player, ID, key, value, text, callback)
 			callback(false)
 			return
 		end
-		
+
 		dbQuery(
-			function(query) 
+			function(query)
 				local result = dbPoll(query,0)
 				local options = fromJSON(result[1].options)
 				if type(options) ~= 'table' then return outputDebugString('GC Perks: wrong options format [' .. forumID, 1) and false end
-				
+
 				options[key] = value
 				options = toJSON(options)
 				if type(options) ~= 'string' then return outputDebugString('GC Perks: error adding option [' .. forumID, 1) and false end
 				local result = dbExec(handlerConnect, "UPDATE gc_items SET options=? WHERE forumID=? AND itembought=?", options, forumID, ID)
-				
+
 				if type(text) == 'string' then
 					outputChatBox(tostring(text), player, 0, 255, 0)
 				end
-				
+
 				callback(result)
-			end, 
+			end,
 		handlerConnect, "SELECT options FROM gc_items WHERE forumid=? AND itembought=?", forumID, ID)
 	end)
 end
@@ -612,7 +612,7 @@ end
 addCommandHandler('gcflipv2', callFlip, false, false)
 -- addCommandHandler('flip', function(p) outputChatBox('p') setElementRotation(getPedOccupiedVehicle(p), 180,0,0) end )
 
-function flipPlayer(player)	
+function flipPlayer(player)
 	local veh = getPedOccupiedVehicle(player)
 
 	busy_with_player[player] = true
@@ -666,7 +666,7 @@ function mapRestart ( mapInfo, mapOptions, gameOptions )
 	if #allSpawnpoints == 0 then
 		--Some maps aren't converted to MTA 1.0 format so they do not return checkpoints.
 		return false
-	end	
+	end
 	-- local c_x, c_y, c_z = getElementPosition(getElementsByType('checkpoint')[1])
 	-- for k,spawn in ipairs(allSpawnpoints) do
 		-- local a_x, a_y, a_z, id, vehID, rot = getSpawnpointPosition ( spawn )
@@ -677,9 +677,12 @@ end
 addEventHandler ( "onMapStarting", root, mapRestart )
 
 function callSpawn ( player )
+    if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
+        exports.cw_script:outputInfoForPlayer(player, "You can't change spawns during events")
+    end
 	if #allSpawnpoints == 0 then
 		return false
-	end	
+	end
 	local currentPlayerState = getElementData(player, 'state', false)
 	local forumID = tonumber(exports.gc:getPlayerForumID ( player ))
 	local elementID
@@ -700,13 +703,13 @@ function callSpawn ( player )
 		-- return outputChatBox('[GC] Changed to spawnpoint \"' .. tostring(elementID) .. '\" .. ('..index..'/'..distance..'m)', player, 0,255,0)
 	end
 end
-	
+
 function changeSpawn (player)
 	local x, y, z, id, vehID, rot
 	local newSpawnpoint, currentSP
 	local x2, y2, z2
 	local distance
-	
+
 	local veh = getPedOccupiedVehicle(player)
 	if not veh then return end
 
@@ -715,20 +718,20 @@ function changeSpawn (player)
 		spawnIndex[player] = 1
 	else
 		-- try to skip spawns at the same position
-		for i=1,25 do 
-			-- go to next/previous spawn 
+		for i=1,25 do
+			-- go to next/previous spawn
 			currentSP = spawnIndex[player] -- current sp
 			spawnIndex[player] = spawnIndex[player] + (getShiftState(player) and -1 or 1) -- next sp
 			-- check bounds
-			if spawnIndex[player] > #allSpawnpoints then spawnIndex[player] = 1 
+			if spawnIndex[player] > #allSpawnpoints then spawnIndex[player] = 1
 			elseif spawnIndex[player] < 1 then spawnIndex[player] = #allSpawnpoints
-			end			
+			end
 			-- check distance between spawn i and i+1
 			x2, y2, z2, _, _, _ = getSpawnpointPosition( allSpawnpoints[currentSP] )
 			x, y, z, _, _, _ = getSpawnpointPosition( allSpawnpoints[spawnIndex[player]] )
 			distance = getDistanceBetweenPoints3D(x, y, z, x2, y2, z2)
 			-- outputChatBox("sp "..currentSP.." -> "..spawnIndex[player]..", dist: ".. distance) -- debug
-			
+
 			-- next sp is far enough, stop searching, example:
 			-- spawn 1 -> 2, dist: 0		bad
 			-- spawn 2 -> 3, dist: 0		bad
@@ -736,18 +739,18 @@ function changeSpawn (player)
 			if distance > 0.5 then
 				break
 			end
-			
+
 		end -- for
 	end
-	
+
 	newSpawnpoint = allSpawnpoints[spawnIndex[player]]
 	x, y, z, id, vehID, rot = getSpawnpointPosition(newSpawnpoint)
-	
+
 	setElementPosition(veh, x,y,z)
 	setElementRotation(veh, 0,0,rot)
 	setElementModel(veh, vehID)
 	setElementHealth(veh, 1000)
-		
+
 	modShopCheckVehicleAgain(player)
 	distance = getElementsByType('checkpoint')[1] and math.floor(100*getDistanceBetweenPoints3D(x,y,z,getElementPosition(getElementsByType('checkpoint')[1])))/100 or 0
 	return id, distance, spawnIndex[player]
@@ -807,7 +810,7 @@ function setPlayerRocketColor(player,color)
 
 	local exec = dbExec(handlerConnect, "UPDATE gc_rocketcolor SET color=? WHERE forumid=?", color:gsub("#",""), fID)
 
-	
+
 	if exec then setElementData(player,"gc_projectilecolor","#"..color) return true end
 
 	return false
@@ -819,7 +822,7 @@ function rockerColorChange(hex)
 	local thePlayer = client
 	if not thePlayer or not isElement(thePlayer) or getElementType(thePlayer) ~= "player" then return end
 	local setColor = setPlayerRocketColor(thePlayer,hex)
-	
+
 	triggerClientEvent(thePlayer,"clientRocketColorChangeConfirm",resourceRoot,setColor or false)
 
 end
@@ -832,13 +835,13 @@ function getPlayerRocketColor(player, callback)
 	end
 
 	local forumID = exports.gc:getPlayerForumID ( player )
-	if not forumID then 
+	if not forumID then
 		callback(false)
 		return
 	end
 
 	dbQuery(
-		function(query) 
+		function(query)
 			local result = dbPoll(query,0)
 
 			if result[1] and result[1]["color"] then
@@ -846,7 +849,7 @@ function getPlayerRocketColor(player, callback)
 				return
 			end
 			callback(false)
-		end, 
+		end,
 	handlerConnect, "SELECT color FROM gc_rocketcolor WHERE forumid=?", forumID)
 end
 
@@ -863,14 +866,14 @@ end
 --------------------------
 function loadDeadlineColorChange ( player, bool )
 	if bool then
-		getPlayerDeadLineColor(player, 
-		function(color) 
+		getPlayerDeadLineColor(player,
+		function(color)
 			if not color then
 				outputDebugString("Could not find Color for "..getPlayerName(player))
 				insertDeadLineColorToDB(player)
 				color = "00FF00"
 			end
-			setElementData(player,"gcshop_deadlinecolor","#"..color:gsub("#","")) 
+			setElementData(player,"gcshop_deadlinecolor","#"..color:gsub("#",""))
 		end)
 	else
 		removeElementData( player, 'gcshop_deadlinecolor' )
@@ -882,7 +885,7 @@ function deadlineColorChange(hex)
 	local thePlayer = client
 	if not thePlayer or not isElement(thePlayer) or getElementType(thePlayer) ~= "player" then return end
 	local setColor = setPlayerDeadLineColor(thePlayer,hex)
-	
+
 	triggerClientEvent(thePlayer,"clientDeadLineColorChangeConfirm",resourceRoot,setColor or false)
 
 end
@@ -895,7 +898,7 @@ function setPlayerDeadLineColor(player,color)
 
 	local exec = dbExec(handlerConnect, "UPDATE gc_deadlinecolor SET color=? WHERE forumid=?", color:gsub("#",""), fID)
 
-	
+
 	if exec then setElementData(player,"gcshop_deadlinecolor","#"..color:gsub("#","")) return true end
 
 	return false
@@ -909,22 +912,22 @@ function getPlayerDeadLineColor(player, callback)
 	end
 
 	local forumID = exports.gc:getPlayerForumID ( player )
-	if not forumID then 
+	if not forumID then
 		callback(false)
-		return false 
+		return false
 	end
 
 	dbQuery(
-		function(query) 
+		function(query)
 			local result = dbPoll(query,0)
 
 			if result[1] and result[1]["color"] then
 				callback(result[1]["color"])
-				return 
+				return
 			end
 
 			callback(false)
-		end, 
+		end,
 	handlerConnect, "SELECT color FROM gc_deadlinecolor WHERE forumid=?", forumID)
 end
 
@@ -946,7 +949,7 @@ function getTimestamp(year, month, day, hour, minute, second)
     local datetime = getRealTime()
     year, month, day = year or datetime.year + 1900, month or datetime.month + 1, day or datetime.monthday
     hour, minute, second = hour or datetime.hour, minute or datetime.minute, second or datetime.second
- 
+
     -- calculate timestamp
     for i=1970, year-1 do
 		timestamp = timestamp + (isLeapYear(i) and 31622400 or 31536000)
@@ -955,10 +958,10 @@ function getTimestamp(year, month, day, hour, minute, second)
 		timestamp = timestamp + ((isLeapYear(year) and i == 2) and 2505600 or monthseconds[i])
 	end
     timestamp = timestamp + 86400 * (day - 1) + 3600 * hour + 60 * minute + second
- 
+
     timestamp = timestamp - 3600 --GMT+1 compensation
     if datetime.isdst then timestamp = timestamp - 3600 end
- 
+
     return timestamp
 end
 

--- a/resources/[gameplay]/gcshop/items/items_s.lua
+++ b/resources/[gameplay]/gcshop/items/items_s.lua
@@ -679,6 +679,7 @@ addEventHandler ( "onMapStarting", root, mapRestart )
 function callSpawn ( player )
     if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
         exports.cw_script:outputInfoForPlayer(player, "You can't change spawns during events")
+        return false
     end
 	if #allSpawnpoints == 0 then
 		return false

--- a/resources/[gameplay]/gcshop/items/items_s.lua
+++ b/resources/[gameplay]/gcshop/items/items_s.lua
@@ -677,10 +677,6 @@ end
 addEventHandler ( "onMapStarting", root, mapRestart )
 
 function callSpawn ( player )
-    if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
-        exports.cw_script:outputInfoForPlayer(player, "You can't change spawns during events")
-        return false
-    end
 	if #allSpawnpoints == 0 then
 		return false
 	end
@@ -691,6 +687,9 @@ function callSpawn ( player )
 		-- return outputChatBox('3. Not allowed at the moment', player, 255, 0, 0 )
 	elseif not forumID then
 		return outputChatBox('You\'re not logged into a Green-Coins account!', player, 255, 0, 0 )
+    elseif getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
+        exports.cw_script:outputInfoForPlayer(player, "You can't change spawns during events")
+        return false
 	elseif not spawnIndex[player] then
 		if gcshopBuyItem ( player, items.Spawn.price, 'Spawn' ) then
 			elementID, distance, index = changeSpawn(player)

--- a/resources/[gameplay]/gcshop/items/regen/regen_s.lua
+++ b/resources/[gameplay]/gcshop/items/regen/regen_s.lua
@@ -26,15 +26,16 @@ function addCarHealth(car, player)
 	-- setElementHealth(car, math.min(addition + x, 1000))  --105/100 = 5% addition
 	-- Do health addition clientside, so we avoid desync mistakes
 	triggerClientEvent(player, "addCarHealth", car, addition)
-	
+
 end
 
 setTimer(function()
 	if not isPerkAllowedInMode(ID) then return end
-	for player, _ in pairs(g_PlayersRegen) do 
-		if isElement(player) and getElementData(player, 'state') == 'alive' 
-			and getPedOccupiedVehicle(player) 
-			and not isVehicleDamageProof(getPedOccupiedVehicle(player)) 
+    if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then return end
+	for player, _ in pairs(g_PlayersRegen) do
+		if isElement(player) and getElementData(player, 'state') == 'alive'
+			and getPedOccupiedVehicle(player)
+			and not isVehicleDamageProof(getPedOccupiedVehicle(player))
 			and not isVehicleBlown(getPedOccupiedVehicle(player))
 			and getElementHealth(getPedOccupiedVehicle(player)) > 250
 			and getElementHealth(getPedOccupiedVehicle(player)) < 1000 then

--- a/resources/[gameplay]/gcshop/items/vehiclereroll/vehreroll_s.lua
+++ b/resources/[gameplay]/gcshop/items/vehiclereroll/vehreroll_s.lua
@@ -2,7 +2,7 @@ local isRerollAllowed = false
 local rerollIntervalTime = 10000 -- time between rerolls in ms
 local rerollPlayer = {}
 
-local playerRolledAmount = {} -- [player] = amount 
+local playerRolledAmount = {} -- [player] = amount
 local maxRollsPerMap = 1
 
 local vehroll_firstcheckpoint = false -- don't allow before first checkpoint reached
@@ -11,9 +11,9 @@ local vehroll_firstCheckpointPlayer = {}
 local vehreroll_vehs = { -- [gamemode] = {vehicle = {}, boat = {}, air = {} }
 	["Never the same"] = {
 		["vehicle"] = {	602, 545, 496, 517, 401, 410, 518, 600, 527, 436, 589, 580, 419, 439, 533, 549, 526, 491, 474, 445, 467, 604, 426, 507, 547, 585,
-					405, 587, 409, 466, 550, 492, 566, 546, 540, 551, 421, 516, 529, 581, 510, 509, 522, 481, 461, 462, 448, 521, 468, 463, 586, 485, 552, 431, 
+					405, 587, 409, 466, 550, 492, 566, 546, 540, 551, 421, 516, 529, 581, 510, 509, 522, 481, 461, 462, 448, 521, 468, 463, 586, 485, 552, 431,
 					438, 437, 574, 420, 525, 408, 416, 596, 433, 597, 427, 599, 490, 528, 601, 407, 428, 544, 523, 470, 598, 499, 588, 609, 403, 498, 514, 524,
-					423, 532, 414, 578, 443, 486, 406, 531, 573, 456, 455, 459, 543, 422, 583, 482, 478, 605, 554, 530, 418, 572, 582, 413, 440, 536, 575, 534, 
+					423, 532, 414, 578, 443, 486, 406, 531, 573, 456, 455, 459, 543, 422, 583, 482, 478, 605, 554, 530, 418, 572, 582, 413, 440, 536, 575, 534,
 					567, 535, 576, 412, 402, 542, 603, 475, 568, 557, 424, 471, 504, 495, 457, 539, 483, 508, 571, 500, 411, 515,
 					444, 556, 429, 541, 559, 415, 561, 480, 560, 562, 506, 565, 451, 434, 558, 494, 555, 502, 477, 503, 579, 400, 404, 489, 505, 479, 442, 458
 				},
@@ -37,7 +37,7 @@ local vehreroll_disallowedVehicles = {[441] = true, [464] = true, [465] = true, 
 
 
 function loadVehicleReroll(player,bool)
-	
+
 	if bool then
 		vehreroll_setBinds(player,bool)
 	else
@@ -68,7 +68,7 @@ function vehroll_raceState(state)
 		vehroll_firstcheckpoint = false
 		vehroll_firstCheckpointPlayer = {}
 	end
-	
+
 end
 addEvent("onRaceStateChanging",true)
 addEventHandler("onRaceStateChanging",root,vehroll_raceState)
@@ -86,14 +86,18 @@ addEventHandler("onPlayerReachCheckpoint",root,vehroll_handleCPReached)
 addCommandHandler( "rerollvehicle", function(player) if isKeyBound( player, "c", "down", rerollPlayerVehicle) then rerollPlayerVehicle(player) end end )
 function rerollPlayerVehicle(player)
 	if not isRerollAllowed then return end
+    if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
+        exports.cw_script:outputInfoForPlayer(player, "You can't reroll during events")
+        return
+    end
 
 
-	if 
-		not player or 
-		not isElement(player) or 
+	if
+		not player or
+		not isElement(player) or
 			getElementType(player) ~= "player" or
-			getElementData(player,"state") ~= "alive" then 
-		return 
+			getElementData(player,"state") ~= "alive" then
+		return
 	end
 
 	if rerollPlayer[player] then
@@ -116,7 +120,7 @@ function rerollPlayerVehicle(player)
 	else
 		checkpoints = false
 	end
-	
+
 	local vehicle = getPedOccupiedVehicle( player )
 
 	local vehicleID = getElementModel(vehicle)
@@ -125,7 +129,7 @@ function rerollPlayerVehicle(player)
 	local randomVehID = vehreroll_getRandomVehicleID(vehicleID, player, checkpoints)
 	if not randomVehID then return end
 
-	
+
 
 	local isSet = exports.race:export_setPlayerVehicle( player, randomVehID )
 
@@ -161,7 +165,7 @@ end
 
 function vehreroll_getRandomVehicleID(ID, player, checkpoints)
 	local gm = exports.race:getRaceMode()
-	
+
 	if gm == "Never the same" then
 		local playerCP = getElementData(player, "race.checkpoint") - 1
 		local cpType
@@ -170,7 +174,7 @@ function vehreroll_getRandomVehicleID(ID, player, checkpoints)
 		else
 			cpType = checkpoints[playerCP].nts
 		end
-		
+
 		if cpType == "custom" then
 			local models = tostring(checkpoints[playerCP].models)
 			if not models then return false end
@@ -201,34 +205,34 @@ function vehreroll_getRandomVehicleID(ID, player, checkpoints)
 				vehType = cpType
 			end
 			if not vehType then return false end
-		
+
 			if vehreroll_vehs[gm] and vehreroll_vehs[gm][vehType] then
 				local theTable = vehreroll_vehs[gm][vehType]
-				
+
 				local returnID
 				for i=1, 10 do
 					returnID = theTable[math.random(1,#theTable)]
 					if returnID ~= ID then break end
 				end
-				
+
 				return returnID
 			end
 		end
 	else
 		local vehType = vehreroll_getVehicleType(ID)
 		if not vehType then return false end
-		
-		
-	
+
+
+
 		if vehreroll_vehs[gm] and vehreroll_vehs[gm][vehType] then
 			local theTable = vehreroll_vehs[gm][vehType]
-			
+
 			local returnID
 			for i=1, 10 do
 				returnID = theTable[math.random(1,#theTable)]
 				if returnID ~= ID then break end
 			end
-			
+
 			return returnID
 		end
 	end
@@ -238,18 +242,18 @@ end
 
 
 
-	
+
 
 
 function vehreroll_getVehicleType(vehicleID)
 	if not vehicleID then return false end
-	
+
 
 	local boat = {430, 446, 452, 453, 454, 472, 473, 484, 493, 595}
 	local air = {460, 476, 511, 512, 513, 519, 520, 553, 577, 592, 593, 417, 425, 447, 469, 487, 488, 497, 548, 563}
 
-	
-	
+
+
 	if not vehicleID then return false end
 
 	for _,id in ipairs(boat) do

--- a/resources/[gameplay]/playerrecord/.gitignore
+++ b/resources/[gameplay]/playerrecord/.gitignore
@@ -1,0 +1,1 @@
+peak.xml

--- a/resources/[race]/race/modes/base.lua
+++ b/resources/[race]/race/modes/base.lua
@@ -75,7 +75,7 @@ function RaceMode:isMapRespawn()
 	return self.getMapOption('respawn') == 'timelimit'
 end
 
-function RaceMode:getRespawntime(player) -- in seconds
+function RaceMode:getRespawntime(player)
     if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
         return g_MapOptions['respawntime']
     end

--- a/resources/[race]/race/modes/base.lua
+++ b/resources/[race]/race/modes/base.lua
@@ -77,9 +77,9 @@ end
 
 function RaceMode:getRespawntime(player) -- in seconds
     if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
-        return self.getMapOption('respawntime')
+        return g_MapOptions['respawntime']
     end
-    local mapRespawnTime = self.getMapOption('respawntime')
+    local mapRespawnTime = g_MapOptions['respawntime']
     local gcShopRespawnTime = tonumber(getElementData(player, 'gcshop.respawntime')) or mapRespawnTime
     return gcShopRespawnTime < mapRespawnTime and gcShopRespawnTime or mapRespawnTime
 end

--- a/resources/[race]/race/modes/base.lua
+++ b/resources/[race]/race/modes/base.lua
@@ -75,6 +75,15 @@ function RaceMode:isMapRespawn()
 	return self.getMapOption('respawn') == 'timelimit'
 end
 
+function RaceMode:getRespawntime(player) -- in seconds
+    if tonumber(getElementData(player, 'gcshop.respawntime')) or self.getMapOption('respawntime') then
+        return self.getMapOption('respawntime')
+    end
+    local mapRespawnTime = self.getMapOption('respawntime')
+    local gcShopRespawnTime = tonumber(getElementData(player, 'gcshop.respawntime')) or mapRespawnTime
+    return gcShopRespawnTime < mapRespawnTime and gcShopRespawnTime or mapRespawnTime
+end
+
 function RaceMode.getPlayers()
 	return g_Players
 end
@@ -270,7 +279,7 @@ function RaceMode:onPlayerReachCheckpoint(player, checkpointNum, nitroLevel, nit
 		self.checkpointBackups[player].goingback = true
 		TimerManager.destroyTimersFor("checkpointBackup",player)
 		-- Edit #2, edit respawn time based on shop perk
-		TimerManager.createTimerFor("map","checkpointBackup",player):setTimer(lastCheckpointWasSafe, tonumber(getElementData(player, 'gcshop.saferespawn')) or 5000, 1, self.id, player)
+		TimerManager.createTimerFor("map","checkpointBackup",player):setTimer(lastCheckpointWasSafe, self.getRespawntime(player), 1, self.id, player)
 	else
 		-- Finish reached
 		rank = getFinishedPlayerCount() + 1
@@ -348,7 +357,7 @@ function RaceMode:onPlayerWasted(player)
 	TimerManager.destroyTimersFor("checkpointBackup",player)
 	if self.getMapOption('respawn') == 'timelimit' and not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime       = tonumber(getElementData(player, 'gcshop.respawntime')) or self.getMapOption('respawntime')
+        local respawnTime = self.getRespawntime(player)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end

--- a/resources/[race]/race/modes/base.lua
+++ b/resources/[race]/race/modes/base.lua
@@ -76,7 +76,7 @@ function RaceMode:isMapRespawn()
 end
 
 function RaceMode:getRespawntime(player) -- in seconds
-    if tonumber(getElementData(player, 'gcshop.respawntime')) or self.getMapOption('respawntime') then
+    if getResourceState(getResourceFromName("cw_script")) == "running" and exports.cw_script:areTeamsSet() then
         return self.getMapOption('respawntime')
     end
     local mapRespawnTime = self.getMapOption('respawntime')
@@ -279,7 +279,7 @@ function RaceMode:onPlayerReachCheckpoint(player, checkpointNum, nitroLevel, nit
 		self.checkpointBackups[player].goingback = true
 		TimerManager.destroyTimersFor("checkpointBackup",player)
 		-- Edit #2, edit respawn time based on shop perk
-		TimerManager.createTimerFor("map","checkpointBackup",player):setTimer(lastCheckpointWasSafe, self.getRespawntime(player), 1, self.id, player)
+		TimerManager.createTimerFor("map","checkpointBackup",player):setTimer(lastCheckpointWasSafe, self:getRespawntime(player), 1, self.id, player)
 	else
 		-- Finish reached
 		rank = getFinishedPlayerCount() + 1
@@ -357,7 +357,7 @@ function RaceMode:onPlayerWasted(player)
 	TimerManager.destroyTimersFor("checkpointBackup",player)
 	if self.getMapOption('respawn') == 'timelimit' and not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime = self.getRespawntime(player)
+        local respawnTime = self:getRespawntime(player)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end

--- a/resources/[race]/race/modes/ctf.lua
+++ b/resources/[race]/race/modes/ctf.lua
@@ -12,10 +12,10 @@ function CTF:isMapValid()
 	local redFlagObjects, blueFlagObjects = #getElementsByType(self.red.FlagType), #getElementsByType(self.blue.FlagType)
 	if redFlagObjects ~= 1 or blueFlagObjects ~= 1 then
 		outputRace('Error. CTF map should have one red flag(' .. redFlagObjects .. ') and one blue flag(' .. blueFlagObjects .. ')')
-		return false 
+		return false
 	elseif self.getNumberOfCheckpoints() > 0 then
 		outputRace('Error. CTF map shouldn\'t have checkpoints')
-		return false 
+		return false
 	else
 		local error = false
 		for i, spawn in ipairs(g_Spawnpoints) do
@@ -45,7 +45,7 @@ function CTF:initTeam(teamTable)
 	teamTable.Team = createTeam(teamTable.name, teamTable.r, teamTable.g, teamTable.b)
 	teamTable.points = 0
 	teamTable.serials = {}
-	
+
 	local flagElement = getElementsByType(teamTable.FlagType)[1]
 	local x,y,z = getElementPosition(flagElement)
 	teamTable.flagObject= createObject(teamTable.FlagModel, x,y,z)
@@ -75,7 +75,7 @@ function CTF:setPlayerTeam(player, teamTable)
 	local r, g, b = getTeamColor(teamTable.Team)
 	createBlipAttachedTo(player, 0, 1, r, g, b)
 	setVehicleColor(g_CurrentRaceMode.getPlayerVehicle( player ), r, g, b, r, g, b, r, g, b, r, g, b)
-	clientCall(root,'applyTeamColorShader',player) 
+	clientCall(root,'applyTeamColorShader',player)
 	showMessage("You have been assigned to the " .. teamTable.name .. "!", r, g, b, player)
 end
 
@@ -148,7 +148,7 @@ function CTF:restorePlayer(id, player, bNoFade, bDontFix)
 	if not bNoFade then
 		clientCall(player, 'remoteStopSpectateAndBlack')
 	end
-	
+
 	local bkp = {}
 	local spawnpoint = self:pickFreeSpawnpoint(player)
 	bkp.position = spawnpoint.position
@@ -177,8 +177,8 @@ function CTF:restorePlayer(id, player, bNoFade, bDontFix)
 		if getElementModel(vehicle) ~= bkp.vehicle then
 			setVehicleID(vehicle, bkp.vehicle)
 		end
-		warpPedIntoVehicle(player, vehicle)	
-		
+		warpPedIntoVehicle(player, vehicle)
+
         setVehicleLandingGearDown(vehicle,bkp.geardown)
 
 		self:playerFreeze(player, true, bDontFix)
@@ -193,7 +193,7 @@ function CTF:restorePlayer(id, player, bNoFade, bDontFix)
 	local team = getPlayerTeam(player)
 	local r, g, b = getTeamColor(team)
 	setVehicleColor(g_CurrentRaceMode.getPlayerVehicle( player ), r, g, b, r, g, b, r, g, b, r, g, b)
-	clientCall(root,'applyTeamColorShader',player) 
+	clientCall(root,'applyTeamColorShader',player)
 end
 
 
@@ -203,7 +203,7 @@ function CTF:onPlayerPickUpRacePickup(player, pickup)
 		local team = getPlayerTeam(player)
 		local r, g, b = getTeamColor(team)
 		setVehicleColor(g_CurrentRaceMode.getPlayerVehicle( player ), r, g, b, r, g, b, r, g, b, r, g, b)
-		clientCall(root,'applyTeamColorShader',player) 
+		clientCall(root,'applyTeamColorShader',player)
 	end
 end
 
@@ -252,10 +252,10 @@ end
 
 function CTF:onPlayerWasted(player)
 	self:dropPlayerFlag(player)
-	
+
 	if self.getMapOption('respawn') == 'timelimit' and not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime       = tonumber(getElementData(player, 'gcshop.respawntime')) or self.getMapOption('respawntime')
+        local respawnTime = self.getRespawntime(player)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end
@@ -292,7 +292,7 @@ end
 
 function CTF:dropPlayerFlag(player)
 	local playerFlag
-	for k, flag in ipairs(Flag.instances) do 
+	for k, flag in ipairs(Flag.instances) do
 		if flag:getCarrier() == player then
 			playerFlag = flag
 		end
@@ -447,13 +447,13 @@ function Flag:new(teamTable, object)
 	t.id = id
 	t.teamTable = teamTable
 	t.object = object
-	
+
 	t.base = {x=x, y=y, z=z}
 	t.basemarker = createMarker(x,y,z, 'cylinder', 1.5, teamTable.r, teamTable.g, teamTable.b, 100)
 	t.basecol = createColSphere(x, y, z, 2)
 	t.blip = createBlipAttachedTo(t.basemarker, 0, 4, teamTable.r, teamTable.g, teamTable.b)
 	addEventHandler('onColShapeHit', t.basecol, Flag.hit)
-	
+
 	t.marker = createMarker(x, y, z, 'corona', 1.5, teamTable.r, teamTable.g, teamTable.b, 100)
 	attachElements( t.marker, t.object)
 	setElementParent( t.marker, t.object)
@@ -462,7 +462,7 @@ function Flag:new(teamTable, object)
 	addEventHandler('onColShapeHit', t.col, Flag.hit)
 	attachElements( t.col, t.object)
 	setElementParent( t.col, t.object)
-	
+
 	-- outputDebugString("New " .. teamTable.name .. " flag (".. id .. ') ' .. tostring((object)) .. " event=" .. tostring(t.col))
 	Flag.instances[id] = setmetatable(t, self)
 	return Flag.instances[id]
@@ -491,7 +491,7 @@ addEvent('onCTFFlagTaken')
 
 function Flag:hitBaseCol(player)
 	local playerFlag = g_CurrentRaceMode:getFlagCarriedBy(player)
-	for k, flag in ipairs(Flag.instances) do 
+	for k, flag in ipairs(Flag.instances) do
 		if flag:getCarrier() == player then
 			playerFlag = flag
 		end
@@ -556,7 +556,7 @@ function Flag:resetToBase()
 	if getElementAttachedTo(self:getObject()) then
 		detachElements(self:getObject())
 	end
-	
+
 	local pos = self:getBase()
 	self:setPosition(pos.x, pos.y, pos.z)
 	playSoundFrontEnd(root, 14)
@@ -640,11 +640,11 @@ function Flag:destroy()
 	for _, v in ipairs(destroy) do
 		if v and isElement(v) then destroyElement(v) end
 	end
-	
+
 	self:resetTimers()
 	self.carrier = nil
 	self.teamTable = nil
-	
+
 	Flag.instances[self.id] = nil
 end
 
@@ -703,6 +703,6 @@ end
 addEvent("ctf_clientVehChange",true)
 local function receiveVehSwitch()
 	if getElementType(client) ~= "player" then return end
-	clientCall(root,'applyTeamColorShader',client) 
+	clientCall(root,'applyTeamColorShader',client)
 end
 addEventHandler("ctf_clientVehChange",root,receiveVehSwitch)

--- a/resources/[race]/race/modes/ctf.lua
+++ b/resources/[race]/race/modes/ctf.lua
@@ -255,7 +255,7 @@ function CTF:onPlayerWasted(player)
 
 	if self.getMapOption('respawn') == 'timelimit' and not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime = self.getRespawntime(player)
+        local respawnTime = self:getRespawntime(player)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end

--- a/resources/[race]/race/modes/nts.lua
+++ b/resources/[race]/race/modes/nts.lua
@@ -28,7 +28,7 @@ function NTS:onPlayerWasted(player)
 	TimerManager.destroyTimersFor("checkpointBackup",player)
 	if not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime = self.getRespawntime(source)
+        local respawnTime = self:getRespawntime(source)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end

--- a/resources/[race]/race/modes/nts.lua
+++ b/resources/[race]/race/modes/nts.lua
@@ -28,7 +28,7 @@ function NTS:onPlayerWasted(player)
 	TimerManager.destroyTimersFor("checkpointBackup",player)
 	if not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime = self:getRespawntime(source)
+        local respawnTime = self:getRespawntime(player)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end

--- a/resources/[race]/race/modes/nts.lua
+++ b/resources/[race]/race/modes/nts.lua
@@ -4,13 +4,13 @@ NTS.__index = NTS
 NTS:register('nts')
 
 function NTS:isMapValid()
-	if self.getNumberOfCheckpoints() < 1 then 
-		outputRace('Error starting NTS map: At least 1 CP needed') 
-		return false 
+	if self.getNumberOfCheckpoints() < 1 then
+		outputRace('Error starting NTS map: At least 1 CP needed')
+		return false
 	end
-	for _, checkpoint in ipairs(self.getCheckpoints()) do 
-		if not self:isValidCheckpoint(checkpoint) then 
-			outputChatBox('Error starting NTS map: Problem with NTS checkpoint #' .. _ .. ' (' .. checkpoint.id .. ')') 
+	for _, checkpoint in ipairs(self.getCheckpoints()) do
+		if not self:isValidCheckpoint(checkpoint) then
+			outputChatBox('Error starting NTS map: Problem with NTS checkpoint #' .. _ .. ' (' .. checkpoint.id .. ')')
 			return false
 		end
 	end
@@ -28,7 +28,7 @@ function NTS:onPlayerWasted(player)
 	TimerManager.destroyTimersFor("checkpointBackup",player)
 	if not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime       = tonumber(getElementData(player, 'gcshop.respawntime')) or self.getMapOption('respawntime')
+        local respawnTime = self.getRespawntime(player)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end
@@ -40,7 +40,7 @@ end
 
 function NTS:start()
 	NTS.custom = {nil}
-	math.randomseed(getTickCount()) 
+	math.randomseed(getTickCount())
 end
 
 function NTS:playerUnfreeze(player, bDontFix)
@@ -85,7 +85,7 @@ local function betterRandom(floor,limit)
 
 	math.randomseed(seed)
 	local rand = math.random(limit)
-	
+
 	return rand
 end
 
@@ -125,20 +125,20 @@ function NTS:getRandomVehicle(checkpoint)
 		end
 	else
 		return false
-	end	
+	end
 	return list[betterRandom(1, #list)]
 end
 
 NTS._cars = { 602, 545, 496, 517, 401, 410, 518, 600, 527, 436, 589, 580, 419, 439, 533, 549, 526, 491, 474, 445, 467, 604, 426, 507, 547, 585,
-	405, 587, 409, 466, 550, 492, 566, 546, 540, 551, 421, 516, 529, 581, 510, 509, 522, 481, 461, 462, 448, 521, 468, 463, 586, 485, 552, 431, 
+	405, 587, 409, 466, 550, 492, 566, 546, 540, 551, 421, 516, 529, 581, 510, 509, 522, 481, 461, 462, 448, 521, 468, 463, 586, 485, 552, 431,
 	438, 437, 574, 420, 525, 408, 416, 596, 433, 597, 427, 599, 490, 528, 601, 407, 428, 544, 523, 470, 598, 499, 588, 609, 403, 498, 514, 524,
-	423, 532, 414, 578, 443, 486, 406, 531, 573, 456, 455, 459, 543, 422, 583, 482, 478, 605, 554, 530, 418, 572, 582, 413, 440, 536, 575, 534, 
+	423, 532, 414, 578, 443, 486, 406, 531, 573, 456, 455, 459, 543, 422, 583, 482, 478, 605, 554, 530, 418, 572, 582, 413, 440, 536, 575, 534,
 	567, 535, 576, 412, 402, 542, 603, 475, 568, 557, 424, 471, 504, 495, 457, 539, 483, 508, 571, 500, 411, 515,
 	444, 556, 429, 541, 559, 415, 561, 480, 560, 562, 506, 565, 451, 434, 558, 494, 555, 502, 477, 503, 579, 400, 404, 489, 505, 479, 442, 458 }
 -- rc's: 441, 464, 594, 501, 465, 564
--- tank: 432, 
+-- tank: 432,
 NTS._planes = {592, 577, 511, 548, 512, 593, 425, 520, 417, 487, 553, 488, 497, 563, 476, 447, 519, 460, 469, 513}
-NTS._boats = {472,473,493,595,484,430,453,452,446,454} 
+NTS._boats = {472,473,493,595,484,430,453,452,446,454}
 
 
 NTS.name = 'Never the same'

--- a/resources/[race]/race/modes/nts.lua
+++ b/resources/[race]/race/modes/nts.lua
@@ -28,7 +28,7 @@ function NTS:onPlayerWasted(player)
 	TimerManager.destroyTimersFor("checkpointBackup",player)
 	if not self.isPlayerFinished(source) then
         -- See if its worth doing a respawn
-        local respawnTime = self.getRespawntime(player)
+        local respawnTime = self.getRespawntime(source)
         if self:getTimeRemaining() - respawnTime > 3000 then
             Countdown.create(respawnTime/1000, self.restorePlayer, 'You will respawn in:', 255, 255, 255, 0.25, 2.5, true, self, self.id, player):start(player)
         end


### PR DESCRIPTION
During events the following perks/purchases are disabled:

- Car upgrades & wheels (wheels can be changed during events using: /wheels offroad|default)
- Car paintjobs
- Changing spawns
- Health Regeneration
- Longer burnup time
- Rerolling vehicles in NTS modes
- Health transfers
- Faster respawning (and faster checkpoint safety)