### PR TITLE
Allow race checkpoints to use a custom blip size

### DIFF
--- a/resources/[race]/race/race_client.lua
+++ b/resources/[race]/race/race_client.lua
@@ -1467,7 +1467,9 @@ function createCheckpoint(i)
 		return
 	end
 	local pos = checkpoint.position
+	local blipSize = checkpoint.blipsize or 2
 	local color = checkpoint.color or { 0, 0, 255 }
+	local alpha = blipSize <= 0 and 0 or 255
 
 	if checkpoint.type == "corona" then
 		custommarker = exports.custom_coronas:createCorona(pos[1], pos[2], pos[3], checkpoint.size+0.1, color[1], color[2], color[3], color[4] or 255)
@@ -1487,11 +1489,11 @@ function createCheckpoint(i)
 	end
 	-- Edit #9, finish icon for last checkpoint
 	if #g_Checkpoints == 1 then
-		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 53, isCurrent and 2 or 1, color[1], color[2], color[3])
+		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 53, isCurrent and blipSize or 1, color[1], color[2], color[3], alpha)
 	elseif (i == (#g_Checkpoints)) then
-		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 53, isCurrent and 2 or 1, color[1], color[2], color[3])
+		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 53, isCurrent and blipSize or 1, color[1], color[2], color[3], alpha)
 	else
-		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 0, isCurrent and 2 or 1, color[1], color[2], color[3])
+		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 0, isCurrent and blipSize or 1, color[1], color[2], color[3], alpha)
 	end
 
 	setBlipOrdering(checkpoint.blip, 1)
@@ -1501,12 +1503,14 @@ end
 function makeCheckpointCurrent(i,bOtherPlayer)
 	local checkpoint = g_Checkpoints[i]
 	local pos = checkpoint.position
+	local blipSize = checkpoint.blipsize or 2
 	local color = checkpoint.color or { 255, 0, 0 }
+	local alpha = blipSize == 0 and 0 or 255
 	if not checkpoint.blip then
-		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 0, 2, color[1], color[2], color[3])
+		checkpoint.blip = createBlip(pos[1], pos[2], pos[3], 0, blipSize, color[1], color[2], color[3], alpha)
 		setBlipOrdering(checkpoint.blip, 1)
 	else
-		setBlipSize(checkpoint.blip, 2)
+		setBlipSize(checkpoint.blip, blipSize)
 	end
 
 	if not checkpoint.type or checkpoint.type == 'checkpoint' then

--- a/resources/[race]/race/racemap.lua
+++ b/resources/[race]/race/racemap.lua
@@ -1,6 +1,6 @@
 g_MapObjAttrs = {
 	spawnpoint = { 'position', 'rotation', 'vehicle', 'paintjob', 'upgrades', 'team' },
-	checkpoint = { 'id', 'nextid', 'position', 'size', 'color', 'type', 'vehicle', 'paintjob', 'upgrades', 'nts' , 'models'},
+	checkpoint = { 'id', 'nextid', 'position', 'size', 'color', 'type', 'vehicle', 'paintjob', 'upgrades', 'nts' , 'models', 'blipsize'},
 	object = { 'position', 'rotation', 'model' },
 	pickup = { 'position', 'type', 'vehicle', 'paintjob', 'upgrades', 'respawn' }
 }


### PR DESCRIPTION
Allows the blips for the dummy checkpoints in the sky in S.' recently added any order maps to be hidden. Hopefully I did this correctly.

MAP CREATORS:
You can now change the blip size of your checkpoints by adding a "blipsize" attribute to the checkpoint's node, and setting its value to an integer. This is recommended for maps where the checkpoints are far away and bigger blips are desired so it's easier to find on the F11 map. Alternatively this is useful for checkpoints that are activated by script instead of hit normally. For example "Pack Mule" has 100 checkpoints used to maintain some sense of logic in the progress bar and player ranking, which manifested themselves in the form of a black up-pointing triangle in the middle of the Los Santos bay. Setting the blipsize to 0 will make it completely invisible. For reference: The default checkpoint blipsize is 2. The size of player blips and the upcoming checkpoint blip is 1. The size of the chased checkpoint blip in "Pack Mule" is 4. Keep in mind that this is a change that applies to this server and 123robot's server only. Until we work out a way to get this feature approved into the official race gamemode, it is recommended that you continue to keep your scripty checkpoints tidy so your maps will also show up well in other and older versions of the race gamemode.