### PR TITLE
fix: reroll gc perk price info when not logged in

### DIFF
--- a/resources/[gameplay]/gcshop/items/items_gui.lua
+++ b/resources/[gameplay]/gcshop/items/items_gui.lua
@@ -186,7 +186,7 @@ function build_itemsWidget(parent, offsetX, offsetY)
 	guiLabelSetHorizontalAlign(gui["labelInfo_11"], "left", true)
 	guiLabelSetVerticalAlign(gui["labelInfo_11"], "top")
 
-	gui["btnBuyPerk_11"] = guiCreateButton(541, 1111, 101, 101, "Price:\n1000 GC", false, gui["scrollAreaItems"])
+	gui["btnBuyPerk_11"] = guiCreateButton(541, 1111, 101, 101, "Price:\n1500 GC", false, gui["scrollAreaItems"])
 	
 	if on_btnBuyPerk_11_clicked then
 		addEventHandler("onClientGUIClick", gui["btnBuyPerk_11"], on_btnBuyPerk_11_clicked, false)


### PR DESCRIPTION
Screenshot from not logged in gc perks tab:
![image](https://github.com/user-attachments/assets/d0258483-67bf-4707-8ee7-0e72f8987861)

After development:
![image](https://github.com/user-attachments/assets/88fe8761-24be-4b52-a8a1-a45a34f02281)
