### PR TITLE
feat: disable getting same vehicle in checkpoint

### DIFF
--- a/resources/[race]/race/modes/base.lua
+++ b/resources/[race]/race/modes/base.lua
@@ -38,7 +38,7 @@ function RaceMode.getCheckpoints()
 	return g_Checkpoints
 end
 
-function RaceMode:getCheckpoint(i)
+function RaceMode:getCheckpoint(i, vehicle)
 	return g_Checkpoints[i]
 end
 

--- a/resources/[race]/race/modes/nts.lua
+++ b/resources/[race]/race/modes/nts.lua
@@ -65,13 +65,13 @@ function NTS:playerUnfreeze(player, bDontFix)
 	addVehicleUpgrade(vehicle, 1010)
 end
 
-function NTS:getCheckpoint(i)
+function NTS:getCheckpoint(i, vehicle)
 	local realcheckpoint = g_Checkpoints[i]
 	local checkpoint = {}
 	for k,v in pairs(realcheckpoint) do
 		checkpoint[k] = v
 	end
-	checkpoint.vehicle = self:getRandomVehicle(checkpoint)
+	checkpoint.vehicle = self:getRandomVehicle(checkpoint, vehicle)
 	return checkpoint
 end
 
@@ -91,7 +91,7 @@ end
 
 
 
-function NTS:getRandomVehicle(checkpoint)
+function NTS:getRandomVehicle(checkpoint, vehicle)
 	if checkpoint.nts == 'boat' then
 		list = NTS._boats
 	elseif checkpoint.nts == 'air' then
@@ -126,7 +126,21 @@ function NTS:getRandomVehicle(checkpoint)
 	else
 		return false
 	end
-	return list[betterRandom(1, #list)]
+
+	if #list < 2 then
+		return list[betterRandom(1, #list)]
+	end
+	
+	local playerVehicleID = getElementModel(vehicle)
+	
+	local filteredList = {}
+	for _, model in ipairs(list) do
+		if model ~= playerVehicleID then
+			table.insert(filteredList, model)
+		end
+	end
+
+	return filteredList[betterRandom(1, #filteredList)]
 end
 
 NTS._cars = { 602, 545, 496, 517, 401, 410, 518, 600, 527, 436, 589, 580, 419, 439, 533, 549, 526, 491, 474, 445, 467, 604, 426, 507, 547, 585,

--- a/resources/[race]/race/race_server.lua
+++ b/resources/[race]/race/race_server.lua
@@ -721,7 +721,7 @@ addEventHandler('onPlayerReachCheckpointInternal', g_Root,
             return
         end
 		local vehicle = g_Vehicles[source]
-		local checkpoint = g_CurrentRaceMode:getCheckpoint(checkpointNum)
+		local checkpoint = g_CurrentRaceMode:getCheckpoint(checkpointNum, vehicle)
 		if checkpoint.vehicle then
 			if getElementModel(vehicle) ~= tonumber(checkpoint.vehicle) then
 				if checkpointNum < #g_Checkpoints then


### PR DESCRIPTION
Description:
The name of the mode is Never The Same, but there is a possibility of the same car appearing in succession from cps and it happens frequently. This PR includes eliminating the possibility of the same vehicle appearing in cp.

Apart from this, after the important updates that came recently (jumping update, removal of dozer and forklift), the game difficulty level has become quite easy. I think this update will be useful in terms of balancing.